### PR TITLE
Type Specific Depenency Extraction and various utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ __*
 /dist
 .zip
 
+TODO.md
+

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "./",
-  "spec_files": ["./test/*.test.ts"],
+  "spec_files": ["./test/**/*.test.ts"],
   "helpers": ["./test/lib/*.js"],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/src/common.ts
+++ b/src/common.ts
@@ -108,75 +108,7 @@ export function createItemWithData (
     );
   });
 }
-/**
- * Get a property out of a deeply nested object
- * Does not handle anything but nested object graph
- *
- * @param obj Object to retrieve value from
- * @param path Path into an object, e.g., "data.values.webmap", where "data" is a top-level property
- *             in obj
- * @return Value at end of path
- */
-export function getProp (
-  obj: { [index: string]: any },
-  path: string
-): any {
-  return path.split(".").reduce(function(prev, curr) {
-    /* istanbul ignore next no need to test undefined scenario */
-    return prev ? prev[curr] : undefined;
-  }, obj);
-}
 
-
-/**
- * Return an array of values from an object, based on an array of property paths
- * 
- * @param obj object to retrive values from
- * @param props Array of paths into the object e.g., "data.values.webmap", where "data" is a top-level property
- * 
- * @return Array of the values plucked from the object
- */
-export function getProps (
-  obj: any,
-  props:string[]
-): any {
-  return props.reduce((a, p) => {
-    const v = getProp(obj, p);
-    if (v) {
-      a.push(v);
-    }
-    return a;
-  }, []);
-}
-
-/**
- * ```js
- * import { cloneObject } from "@esri/hub-common";
- * const original = { foo: "bar" }
- * const copy = cloneObject(original)
- * copy.foo // "bar"
- * copy === original // false
- * ```
- * Make a deep clone, including arrays. Does not handle functions!
- */
-export function cloneObject(obj: { [index: string]: any }) {
-  let clone: { [index: string]: any } = {};
-  // first check array
-  if (Array.isArray(obj)) {
-    clone = obj.map(cloneObject);
-  } else if (typeof obj === "object") {
-    for (const i in obj) {
-      if (obj[i] != null && typeof obj[i] === "object") {
-        clone[i] = cloneObject(obj[i]);
-      } else {
-        clone[i] = obj[i];
-      }
-    }
-  } else {
-    clone = obj;
-  }
-  return clone;
-}
 
 /**
  * Updates the URL of an item.

--- a/src/common.ts
+++ b/src/common.ts
@@ -127,6 +127,57 @@ export function getProp (
   }, obj);
 }
 
+
+/**
+ * Return an array of values from an object, based on an array of property paths
+ * 
+ * @param obj object to retrive values from
+ * @param props Array of paths into the object e.g., "data.values.webmap", where "data" is a top-level property
+ * 
+ * @return Array of the values plucked from the object
+ */
+export function getProps (
+  obj: any,
+  props:string[]
+): any {
+  return props.reduce((a, p) => {
+    const v = getProp(obj, p);
+    if (v) {
+      a.push(v);
+    }
+    return a;
+  }, []);
+}
+
+/**
+ * ```js
+ * import { cloneObject } from "@esri/hub-common";
+ * const original = { foo: "bar" }
+ * const copy = cloneObject(original)
+ * copy.foo // "bar"
+ * copy === original // false
+ * ```
+ * Make a deep clone, including arrays. Does not handle functions!
+ */
+export function cloneObject(obj: { [index: string]: any }) {
+  let clone: { [index: string]: any } = {};
+  // first check array
+  if (Array.isArray(obj)) {
+    clone = obj.map(cloneObject);
+  } else if (typeof obj === "object") {
+    for (const i in obj) {
+      if (obj[i] != null && typeof obj[i] === "object") {
+        clone[i] = cloneObject(obj[i]);
+      } else {
+        clone[i] = obj[i];
+      }
+    }
+  } else {
+    clone = obj;
+  }
+  return clone;
+}
+
 /**
  * Updates the URL of an item.
  *

--- a/src/itemTypes/dashboard.ts
+++ b/src/itemTypes/dashboard.ts
@@ -17,6 +17,7 @@
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 import * as mCommon from "../common";
+import {getProp} from '../utils/object-helpers';
 import { ITemplate } from "../interfaces";
 
 // -- Exports -------------------------------------------------------------------------------------------------------//
@@ -51,7 +52,7 @@ export function getDependencies (
   return new Promise(resolve => {
     const dependencies:string[] = [];
 
-    const widgets:IDashboardWidget[] = mCommon.getProp(fullItem, "data.widgets");
+    const widgets:IDashboardWidget[] = getProp(fullItem, "data.widgets");
     if (widgets) {
       widgets.forEach((widget:any) => {
         if (widget.type === "mapWidget") {
@@ -76,7 +77,7 @@ export function swizzleDependencies (
   swizzles: mCommon.ISwizzleHash
 ): void {
   // Swizzle its webmap(s)
-  const widgets:IDashboardWidget[] = mCommon.getProp(fullItem, "data.widgets");
+  const widgets:IDashboardWidget[] = getProp(fullItem, "data.widgets");
   if (Array.isArray(widgets)) {
     widgets.forEach(widget => {
       if (widget.type === "mapWidget") {

--- a/src/itemTypes/page.ts
+++ b/src/itemTypes/page.ts
@@ -1,0 +1,15 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */

--- a/src/itemTypes/site.ts
+++ b/src/itemTypes/site.ts
@@ -17,14 +17,15 @@
 /**
  * Site Item Utility Functions
  */
-import { getProp } from '../common';
+import { getProp } from '../utils/object-helpers';
 import { getLayoutDependencies } from '../utils/layout-dependencies';
+
 /**
  * Return a list of items this site depends on
  */
 export function getDependencies (
   model: any
-  ): any {
+  ): Promise<string[]>  {
   const layout = getProp(model, 'data.values.layout') || {};
-  return getLayoutDependencies(layout);
+  return Promise.resolve(getLayoutDependencies(layout));
 };

--- a/src/itemTypes/site.ts
+++ b/src/itemTypes/site.ts
@@ -1,0 +1,30 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+/**
+ * Site Item Utility Functions
+ */
+import { getProp } from '../common';
+import { getLayoutDependencies } from '../utils/layout-dependencies';
+/**
+ * Return a list of items this site depends on
+ */
+export function getDependencies (
+  model: any
+  ): any {
+  const layout = getProp(model, 'data.values.layout') || {};
+  return getLayoutDependencies(layout);
+};

--- a/src/itemTypes/storymap.ts
+++ b/src/itemTypes/storymap.ts
@@ -61,7 +61,7 @@ export function getCascadeDependencies (
 export function getMapSeriesDependencies (
   model:any
   ):string[] {
-  const deps = getProps(model, ['data.values.webmap']) || [];
+  const deps = getProps(model, ['data.values.webmap']);
   const entries = getProp(model, 'data.values.story.entries') || [];
   entries.forEach((e:any) => {
     const entryWebmaps = getDeepValues(e, 'webmap').map((obj:any) => {

--- a/src/itemTypes/storymap.ts
+++ b/src/itemTypes/storymap.ts
@@ -13,3 +13,93 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
+
+import {getProp, getProps, getDeepValues} from '../utils/object-helpers';
+import { hasTypeKeyword, parseIdFromUrl } from '../utils/item-helpers';
+
+/**
+ * Return a list of items this depends on
+ */
+export function getDependencies (
+  model:any)
+  : Promise<string[]> {
+  // unknown types have no deps...
+  let processor = (m:any) => [] as any;
+  // find known types by typeKeyword
+  if (hasTypeKeyword(model, 'Cascade')) {
+    processor = getCascadeDependencies;
+  }
+  if (hasTypeKeyword(model, 'MapJournal')) {
+    processor = getMapJournalDependencies;
+  }
+
+  if (hasTypeKeyword(model, 'mapseries')) {
+    processor = getMapSeriesDependencies;
+  }
+  // execute
+  return Promise.resolve(processor(model));
+};
+
+/**
+ * Cascade specific logic
+ */
+export function getCascadeDependencies (
+  model:any
+  ):string[] {
+  // Cascade Example QA b908258efbba4f019450db46382a0c13
+  const sections = getProp(model, 'data.values.sections') || [];
+  return sections.reduce((a:any, s:any) => {
+    return a.concat(getDeepValues(s, 'webmap').map((e:any) => {
+      return e.id;
+    }));
+  }, []);
+};
+
+/**
+ * Map Series specific logic
+ */
+export function getMapSeriesDependencies (
+  model:any
+  ):string[] {
+  const deps = getProps(model, ['data.values.webmap']) || [];
+  const entries = getProp(model, 'data.values.story.entries') || [];
+  entries.forEach((e:any) => {
+    const entryWebmaps = getDeepValues(e, 'webmap').map((obj:any) => {
+      return obj.id;
+    });
+    // may be dupes...
+    entryWebmaps.forEach((id) => {
+      if (deps.indexOf(id) === -1) {
+        deps.push(id);
+      }
+    });
+  });
+  return deps;
+};
+
+export function getMapJournalDependencies (
+  model:any
+  ):string[] {
+  // MapJournal example QA 4c4d084c22d249fdbb032e4143c62546
+  const sections = getProp(model, 'data.values.story.sections') || [];
+
+  const deps = sections.reduce((a:any, s:any) => {
+    if (s.media) {
+      if (s.media.type === 'webmap') {
+        const v = getProp(s, 'media.webmap.id');
+        if (v) {
+          a.push(v);
+        }
+      }
+      if (s.media.type === 'webpage') {
+        const url = getProp(s, 'media.webpage.url');
+        const id = parseIdFromUrl(url);
+        if (id) {
+          a.push(id);
+        }
+      }
+    }
+    return a;
+  }, []);
+  return deps;
+};

--- a/src/itemTypes/storymap.ts
+++ b/src/itemTypes/storymap.ts
@@ -1,0 +1,15 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */

--- a/src/itemTypes/survey.ts
+++ b/src/itemTypes/survey.ts
@@ -1,0 +1,15 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */

--- a/src/itemTypes/webappbuilder.ts
+++ b/src/itemTypes/webappbuilder.ts
@@ -13,3 +13,19 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
+
+import { getProp } from '../utils/object-helpers';
+
+/**
+ * Return a list of items this site depends on
+ */
+export function getDependencies (
+  model: any
+  ): Promise<string[]>  {
+    const deps = [];
+    const v = getProp(model, 'data.map.itemId');
+    if (v) {
+      deps.push(v);
+    }
+    return Promise.resolve(deps);
+};

--- a/src/itemTypes/webappbuilder.ts
+++ b/src/itemTypes/webappbuilder.ts
@@ -1,0 +1,15 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */

--- a/src/itemTypes/webmappingapplication.ts
+++ b/src/itemTypes/webmappingapplication.ts
@@ -15,6 +15,7 @@
  */
 
 import * as mCommon from "../common";
+import {getProp} from '../utils/object-helpers';
 import { ITemplate } from "../interfaces";
 
 // -- Exports -------------------------------------------------------------------------------------------------------//
@@ -32,7 +33,7 @@ export function getDependencies (
   return new Promise(resolve => {
     const dependencies:string[] = [];
 
-    const values = mCommon.getProp(fullItem, "data.values");
+    const values = getProp(fullItem, "data.values");
     if (values) {
       if (values.webmap) {
         dependencies.push(values.webmap);
@@ -58,7 +59,7 @@ export function swizzleDependencies (
   swizzles: mCommon.ISwizzleHash
 ): void {
   // Swizzle its webmap or group
-  const values = mCommon.getProp(fullItem, "data.values");
+  const values = getProp(fullItem, "data.values");
   if (values) {
     if (values.webmap) {
       values.webmap = swizzles[values.webmap].id;

--- a/src/utils/is-guid.ts
+++ b/src/utils/is-guid.ts
@@ -15,19 +15,18 @@
  */
 
 /**
- * Page Item Utility Functions
+ * Check if a given string is a GUID
+ * @param stringToTest string that may be a guid
+ * 
+ * @returns boolean indicating if the string is a guid
  */
-import { getProp } from '../utils/object-helpers';
-import { getLayoutDependencies } from '../utils/layout-dependencies';
-
-/**
- * Return a list of items this page depends on.
- * Currently this is just considering the layout
- */
-export function getDependencies (
-  model: any
-  ): Promise<string[]>  {
-  const layout = getProp(model, 'data.values.layout') || {};
-  return Promise.resolve(getLayoutDependencies(layout));
-};
-
+export default function isGuid (stringToTest:any):boolean {
+  if (typeof stringToTest !== 'string') {
+    return false;
+  }
+  if (stringToTest[0] === '{') {
+    stringToTest = stringToTest.substring(1, stringToTest.length - 1);
+  }
+  const regexGuid = /^(\{){0,1}[0-9a-fA-F]{8}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{12}(\}){0,1}$/gi;
+  return regexGuid.test(stringToTest);
+}

--- a/src/utils/item-helpers.ts
+++ b/src/utils/item-helpers.ts
@@ -52,6 +52,9 @@ export function parseIdFromUrl (
   url:string
   ):string {
   let id = null;
+  if (!url) {
+    return id;
+  }
   const qs = url.split('?')[1];
   if (qs) {
     id = qs.split('&').reduce((a, p) => {

--- a/src/utils/item-helpers.ts
+++ b/src/utils/item-helpers.ts
@@ -1,0 +1,66 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+
+import {getProp} from '../utils/object-helpers';
+import isGuid from '../utils/is-guid';
+
+/**
+ * Does the model have a specific typeKeyword?
+ */
+export function hasTypeKeyword (
+  model:any,
+  keyword:string
+  ):boolean {
+  const typeKeywords = getProp(model, 'item.typeKeywords') || model.typeKeywords || [];
+  return typeKeywords.includes(keyword);
+};
+
+/**
+ * Does the model have any of a set of keywords
+ */
+export function hasAnyKeyword (
+  model:any, 
+  keywords:string[]
+  ):boolean {
+  const typeKeywords = getProp(model, 'item.typeKeywords') || model.typeKeywords || [];
+  return keywords.reduce((a, kw) => {
+    if (!a) {
+      a = typeKeywords.includes(kw);
+    }
+    return a;
+  }, false);
+};
+
+/**
+ * Given the url of a webapp, parse our the id from the url
+ */
+export function parseIdFromUrl (
+  url:string
+  ):string {
+  let id = null;
+  const qs = url.split('?')[1];
+  if (qs) {
+    id = qs.split('&').reduce((a, p) => {
+      const part = p.split('=')[1];
+      if (part && isGuid(part)) {
+        a = part;
+      }
+      return a;
+    }, null);
+  }
+  return id;
+};

--- a/src/utils/layout-converter.ts
+++ b/src/utils/layout-converter.ts
@@ -16,7 +16,7 @@
 /**
  * Site and Page Layout Conversion functions
  */
-import { cloneObject, getProp } from '../common';
+import { cloneObject, getProp } from '../utils/object-helpers';
 /**
  * Walk the tree and templatize the layout...
  */

--- a/src/utils/layout-converter.ts
+++ b/src/utils/layout-converter.ts
@@ -1,0 +1,264 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+/**
+ * Site and Page Layout Conversion functions
+ */
+import { cloneObject, getProp } from '../common';
+/**
+ * Walk the tree and templatize the layout...
+ */
+
+
+/**
+ * Convert a Layout instance to a Template
+ * 
+ * @param layout Layout Object
+ * 
+ * @returns Hash with the converted Layout, as well as an array of assets
+ */
+export function convertLayoutToTemplate (
+  layout: any
+  ): any {
+  if (!layout) {
+    return layout;
+  }
+
+  // walk the sections, rows, cards... then call to fn's to convert specific cards...
+  const converted = layout.sections.reduce((acc:any, section:any) => {
+    const convertedSection = convertSection(section);
+    acc.assets = acc.assets.concat(convertedSection.assets);
+    acc.sections.push(convertedSection.section);
+    return acc;
+  }, {assets: [], sections: []});
+  // assemble the response
+  const result = {
+    assets: converted.assets,
+    layout: {
+      sections: converted.sections,
+      header: {},
+      footer: {}
+    }
+  };
+  if (layout.header) {
+    result.layout.header = cloneObject(layout.header);
+  }
+  if (layout.footer) {
+    result.layout.footer = cloneObject(layout.footer);
+  }
+  return result;
+};
+
+/**
+ * Convert a section, collecting assets along the way...
+ */
+export function convertSection (
+  section: any
+  ):any {
+  const clone = cloneObject(section);
+  // if the section has a background image, and it has a url, we should
+  // add that to the asset hash so it can be downloaded and added to the template item
+  // and also cook some unique asset name so we can inject a placeholder
+  const rowResult = section.rows.reduce((acc:any, row: any) => {
+    const convertedRow = convertRow(row);
+    // concat in the assets...
+    acc.assets = acc.assets.concat(convertedRow.assets);
+    acc.rows.push({cards: convertedRow.cards});
+    return acc;
+  }, {assets: [], rows: []});
+
+  clone.rows = rowResult.rows;
+  const result = {
+    section: clone,
+    assets: rowResult.assets
+  };
+  // check for assets...
+  if (getProp(clone, 'style.background.fileSrc')) {
+    result.assets = result.assets.concat(extractAssets(clone.style.background));
+  }
+  // return the section and assets...
+  return result;
+};
+
+export function extractAssets (
+  obj: any
+  ): any {
+  const assets = [];
+  if (obj.fileSrc) {
+    assets.push(obj.fileSrc);
+  }
+  if (obj.cropSrc) {
+    assets.push(obj.cropSrc);
+  }
+  return assets;
+};
+
+/**
+ * Convert a row, really just iterates the cards and collects their outputs
+ * @param row Row object, which will contain cards
+ * 
+ * @returns Hash of assets and converted cards
+ */
+export function convertRow (
+  row: any
+  ):any  {
+  // if the section has a background image, and it has a url, we should
+  // add that to the asset hash so it can be downloaded and added to the template item
+  // and also cook some unique asset name so we can inject a placeholder
+  return row.cards.reduce((acc:any, card:any) => {
+    // convert the card...
+    const result = convertCard(card);
+    // concat in the assets...
+    acc.assets = acc.assets.concat(result.assets);
+    // and stuff in the converted card...
+    acc.cards.push(result.card);
+    // return the acc...
+    return acc;
+  }, {assets: [], cards: []});
+};
+
+/**
+ * Convert a card to a templatized version of itself
+ * @param card Card object
+ * 
+ * @returns Hash of the conveted card and any assets
+ */
+export function convertCard (
+  card: any
+  ):any {
+  const clone = cloneObject(card);
+  switch (clone.component.name) {
+    case 'event-list-card':
+      return convertEventListCard(clone);
+    case 'follow-initiative-card':
+      return convertFollowCard(clone);
+    case 'items/gallery-card':
+      return convertItemGalleryCard(clone);
+    case 'image-card':
+      return convertImageCard(clone);
+    case 'jumbotron-card':
+      return convertJumbotronCard(clone);
+    default:
+      return {card: clone, assets: []};
+  }
+};
+
+// ------------- CARD SPECIFIC FUNCTIONS -----------------
+
+/**
+ * Convert an Image Card 
+ * @param card Card Object 
+ * 
+ * @returns Hash including the converted card, and any assets
+ */
+export function convertImageCard (
+  card:any
+  ):any {
+  const result = {
+    card,
+    assets: [] as any[]
+  };
+  if (getProp(card, 'component.settings.fileSrc')) {
+    result.assets.push(card.component.settings.fileSrc);
+  }
+  if (getProp(card, 'component.settings.cropSrc')) {
+    result.assets.push(card.component.settings.cropSrc);
+  }
+  return result;
+};
+
+/**
+ * Convert an Jumbotron Card 
+ * @param card Card Object 
+ * 
+ * @returns Hash including the converted card, and any assets
+ */
+export function convertJumbotronCard (
+  card:any
+  ):any  {
+  const result = {
+    card,
+    assets: [] as any[]
+  };
+  if (getProp(card, 'component.settings.fileSrc')) {
+    result.assets.push(card.component.settings.fileSrc);
+  }
+  if (getProp(card, 'component.settings.cropSrc')) {
+    result.assets.push(card.component.settings.cropSrc);
+  }
+  return result;
+};
+
+/**
+ * Convert an Item Gallery Card 
+ * @param card Card Object 
+ * 
+ * @returns Hash including the converted card, and any assets
+ */
+export function convertItemGalleryCard (
+  card:any
+  ):any  {
+  const settings = card.component.settings;
+  if (settings.groups) {
+    settings.groups = [
+      {
+        title: '{{initiative.name}}',
+        id: '{{initiative.collaborationGroupId}}'
+      }
+    ];
+  }
+
+  if (getProp(settings, 'query.groups')) {
+    settings.query.groups = [
+      {
+        title: '{{initiative.name}}',
+        id: '{{initiative.collaborationGroupId}}'
+      }
+    ];
+  }
+
+  settings.orgId = '{{organization.id}}';
+  if (settings.siteId) {
+    settings.siteId = '{{appid}}';
+  }
+
+  return {card, assets: []};
+};
+
+/**
+ * Convert an Follow Initiative Card 
+ * @param card Card Object 
+ * 
+ * @returns Hash including the converted card, and any assets
+ */
+export function convertFollowCard (
+  card:any
+  ):any  {
+  card.component.settings.initiativeId = '{{initiative.id}}';
+  return {card, assets: [] as any[]};
+};
+
+/**
+ * Convert an Event List Card 
+ * @param card Card Object 
+ * 
+ * @returns Hash including the converted card, and any assets
+ */
+export function convertEventListCard (
+  card:any
+  ):any  {
+  card.component.settings.initiativeIds = ['{{initiative.id}}'];
+  return {card, assets: []};
+};

--- a/src/utils/layout-dependencies.ts
+++ b/src/utils/layout-dependencies.ts
@@ -1,0 +1,109 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+/**
+ * Site and Page Layout Depdendency functions
+ */
+import { getProp } from '../common';
+
+
+/**
+ * Entry point that walks the Layout object graph and inspects
+ * the Sections/Rows/Cards for dependencies
+ * 
+ * @param layout Layout object 
+ * 
+ * @returns Array of the id's of the dependant items
+ */
+export function getLayoutDependencies (
+  layout:any
+  ): any {
+  return layout.sections.reduce((deps:any, section:any) => {
+    return deps.concat(getSectionDependencies(section));
+  }, []);
+};
+
+/**
+ * Iterate the Rows in the Section...
+ * @param section Section Object 
+ * 
+ * @returns Array of the id's of the dependant items
+ */
+export function getSectionDependencies (
+  section:any
+  ):any {
+  return section.rows.reduce((deps:any, row:any) => {
+    return deps.concat(getRowDependencies(row));
+  }, []);
+};
+/**
+ * Iterate the Cards in the Row...
+ * @param row Row Object 
+ * 
+ * @returns Array of the id's of the dependant items
+ */
+export function getRowDependencies (
+  row:any
+  ):any {
+  return row.cards.reduce((deps:any, card:any) => {
+    const cardDeps = getCardDependencies(card);
+    if (cardDeps.length) {
+      deps = deps.concat(cardDeps);
+    }
+    return deps;
+  }, []);
+};
+
+/**
+ * Parse the card settings to extract the dependency ids.
+ * This is where the actual useful work happens
+ * 
+ * @param card Card Object 
+ * 
+ * @returns Array of the id's of the dependant items
+ */
+export function getCardDependencies (
+  card:any
+  ):any {
+  let paths = [] as any[];
+  const componentName = getProp(card, 'component.name');
+  
+  switch (componentName) {
+    case 'chart-card':
+      paths = ['component.settings.itemId'];
+      break;
+    case 'summary-statistic-card':
+      paths = ['component.settings.itemId'];
+      break;
+    case 'webmap-card':
+      paths = ['component.settings.webmap'];
+      break;
+    case 'items/gallery-card':
+      paths = ['component.settings.ids'];
+      break;
+  }
+  
+  return paths.reduce((a, p) => {
+    const v = getProp(card, p);
+    if (v) {
+      if (Array.isArray(v)) {
+        a = a.concat(v);
+      } else {
+        a.push(v);
+      }
+    }
+    return a;
+  }, []);
+};

--- a/src/utils/layout-dependencies.ts
+++ b/src/utils/layout-dependencies.ts
@@ -16,7 +16,7 @@
 /**
  * Site and Page Layout Depdendency functions
  */
-import { getProp } from '../common';
+import { getProp } from '../utils/object-helpers';;
 
 
 /**
@@ -30,7 +30,8 @@ import { getProp } from '../common';
 export function getLayoutDependencies (
   layout:any
   ): any {
-  return layout.sections.reduce((deps:any, section:any) => {
+    const sections = layout.sections || [];
+  return sections.reduce((deps:any, section:any) => {
     return deps.concat(getSectionDependencies(section));
   }, []);
 };
@@ -58,11 +59,7 @@ export function getRowDependencies (
   row:any
   ):any {
   return row.cards.reduce((deps:any, card:any) => {
-    const cardDeps = getCardDependencies(card);
-    if (cardDeps.length) {
-      deps = deps.concat(cardDeps);
-    }
-    return deps;
+    return deps.concat(getCardDependencies(card));
   }, []);
 };
 

--- a/src/utils/object-helpers.ts
+++ b/src/utils/object-helpers.ts
@@ -1,0 +1,110 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+/**
+ * Get a property out of a deeply nested object
+ * Does not handle anything but nested object graph
+ *
+ * @param obj Object to retrieve value from
+ * @param path Path into an object, e.g., "data.values.webmap", where "data" is a top-level property
+ *             in obj
+ * @return Value at end of path
+ */
+export function getProp (
+  obj: { [index: string]: any },
+  path: string
+): any {
+  return path.split(".").reduce(function(prev, curr) {
+    /* istanbul ignore next no need to test undefined scenario */
+    return prev ? prev[curr] : undefined;
+  }, obj);
+}
+
+
+/**
+ * Return an array of values from an object, based on an array of property paths
+ * 
+ * @param obj object to retrive values from
+ * @param props Array of paths into the object e.g., "data.values.webmap", where "data" is a top-level property
+ * 
+ * @return Array of the values plucked from the object
+ */
+export function getProps (
+  obj: any,
+  props:string[]
+): any {
+  return props.reduce((a, p) => {
+    const v = getProp(obj, p);
+    if (v) {
+      a.push(v);
+    }
+    return a;
+  }, []);
+}
+
+/**
+ * ```js
+ * import { cloneObject } from "utils/object-helpers";
+ * const original = { foo: "bar" }
+ * const copy = cloneObject(original)
+ * copy.foo // "bar"
+ * copy === original // false
+ * ```
+ * Make a deep clone, including arrays. Does not handle functions!
+ */
+export function cloneObject(obj: { [index: string]: any }) {
+  let clone: { [index: string]: any } = {};
+  // first check array
+  if (Array.isArray(obj)) {
+    clone = obj.map(cloneObject);
+  } else if (typeof obj === "object") {
+    for (const i in obj) {
+      if (obj[i] != null && typeof obj[i] === "object") {
+        clone[i] = cloneObject(obj[i]);
+      } else {
+        clone[i] = obj[i];
+      }
+    }
+  } else {
+    clone = obj;
+  }
+  return clone;
+}
+
+/**
+ * Look for a specific property name anywhere inside an object graph
+ * and return the value
+ */
+export function getDeepValues (obj:any, prop:string): string[] {
+  let result = [] as string[];
+  if (!obj) return result;
+  let p;
+  for (p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      if (p === prop) {
+        result.push(obj[p]);
+      } else {
+        if (Array.isArray(obj[p])) {
+          obj[p].forEach((e:any) => {
+            result = result.concat(getDeepValues(e, prop));
+          });
+        } else if (typeof obj[p] === 'object') {
+          result = result.concat(getDeepValues(obj[p], prop));
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -14,20 +14,4 @@
  | limitations under the License.
  */
 
-/**
- * Page Item Utility Functions
- */
-import { getProp } from '../utils/object-helpers';
-import { getLayoutDependencies } from '../utils/layout-dependencies';
-
-/**
- * Return a list of items this page depends on.
- * Currently this is just considering the layout
- */
-export function getDependencies (
-  model: any
-  ): Promise<string[]>  {
-  const layout = getProp(model, 'data.values.layout') || {};
-  return Promise.resolve(getLayoutDependencies(layout));
-};
-
+// TODO: This file should have tests for all functions in common.ts

--- a/test/fixtures/cascade-storymap.ts
+++ b/test/fixtures/cascade-storymap.ts
@@ -1,0 +1,316 @@
+export default  {
+  'source': 'fc14b48f49754353b7a94b27ed9ac731',
+  'folderId': 'ebbdd10ebdc8461eacf44a643d6bc10f',
+  'values': {
+    'config': {
+      'author': {
+        'name': ''
+      }
+    },
+    'settings': {
+      'theme': {
+        'colors': {
+          'id': 'black-on-white-1',
+          'label': 'Light',
+          'themeMajor': 'light',
+          'themeContrast': 'dark',
+          'bgMain': 'white',
+          'textMain': '#4c4c4c'
+        }
+      },
+      'header': {}
+    },
+    'template': {
+      'name': 'Story Map Cascade',
+      'createdWith': '1.7.1',
+      'editedWith': '1.7.1',
+      'dataVersion': '1.0.0'
+    },
+    'sections': [
+      {
+        'type': 'cover',
+        'foreground': {
+          'title': 'Cascade',
+          'subtitle': '',
+          'options': {
+            'titleStyle': {
+              'shadow': false,
+              'text': 'dark',
+              'background': 'light'
+            }
+          }
+        },
+        'options': {},
+        'layout': 'cover-1',
+        'background': {
+          'type': 'image',
+          'image': {
+            'url': 'resources/tpl/viewer/cover-placeholder/SteveRichey.jpg',
+            'isPlaceholder': true,
+            'options': {
+              'size': 'small'
+            },
+            'width': 1920,
+            'height': 1080
+          }
+        }
+      },
+      {
+        'type': 'sequence',
+        'background': {
+          'type': 'color',
+          'color': {
+            'value': 'white'
+          }
+        },
+        'foreground': {
+          'blocks': [
+            {
+              'type': 'webmap',
+              'webmap': {
+                'type': 'webmap',
+                'id': '234a94478490445cb4a57878451cb4b8',
+                'options': {
+                  'interaction': 'disabled',
+                  'size': 'medium'
+                },
+                'extras': {
+                  'locate': {
+                    'enabled': false
+                  },
+                  'search': {
+                    'enabled': false
+                  },
+                  'legend': {
+                    'enabled': false
+                  }
+                },
+                'caption': '',
+                'popup': {
+                  'layerId': 'DC_Police_4501',
+                  'fieldName': 'FID',
+                  'fieldValue': 9,
+                  'anchorPoint': {
+                    'x': -8573958.201735364,
+                    'y': 4707431.842080245,
+                    'spatialReference': {
+                      'wkid': 102100
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        'type': 'immersive',
+        'options': {},
+        'views': [
+          {
+            'transition': 'fade-fast',
+            'background': {
+              'type': 'webmap',
+              'webmap': {
+                'type': 'webmap',
+                'id': '7db923b748c44666b09afc83ce833b87',
+                'options': {
+                  'interaction': 'disabled'
+                },
+                'extras': {
+                  'locate': {
+                    'enabled': false
+                  },
+                  'search': {
+                    'enabled': false
+                  },
+                  'legend': {
+                    'enabled': false
+                  }
+                },
+                'extent': {
+                  'xmin': -14265018.319190815,
+                  'ymin': 2321631.7425200106,
+                  'xmax': -7724454.682886593,
+                  'ymax': 7110870.186754741,
+                  'spatialReference': {
+                    'wkid': 102100
+                  }
+                },
+                'layers': []
+              }
+            },
+            'foreground': {
+              'panels': [
+                {
+                  'layout': 'scroll-full',
+                  'settings': {
+                    'position-x': 'left',
+                    'size': 'medium',
+                    'style': 'background',
+                    'theme': 'white-over-black'
+                  },
+                  'blocks': [
+                    {
+                      'type': 'text',
+                      'text': {
+                        'value': '<p class="block">dis</p>'
+                      }
+                    }
+                  ]
+                }
+              ],
+              'title': {
+                'value': '',
+                'global': true,
+                'style': {
+                  'shadow': false,
+                  'text': 'dark',
+                  'background': 'light'
+                }
+              }
+            }
+          },
+          {
+            'transition': 'none',
+            'background': {
+              'type': 'webmap',
+              'webmap': {
+                'type': 'webmap',
+                'id': '7db923b748c44666b09afc83ce833b87',
+                'options': {
+                  'interaction': 'button'
+                },
+                'extras': {
+                  'locate': {
+                    'enabled': false
+                  },
+                  'search': {
+                    'enabled': false
+                  },
+                  'legend': {
+                    'enabled': false
+                  }
+                },
+                'layers': [],
+                'extent': {
+                  'xmin': -14265018.319190815,
+                  'ymin': 2321631.7425200106,
+                  'xmax': -7724454.682886593,
+                  'ymax': 7110870.186754741,
+                  'spatialReference': {
+                    'wkid': 102100
+                  }
+                }
+              }
+            },
+            'foreground': {
+              'panels': [
+                {
+                  'layout': 'scroll-full',
+                  'settings': {
+                    'position-x': 'left',
+                    'size': 'medium',
+                    'style': 'background',
+                    'theme': 'white-over-black'
+                  },
+                  'blocks': [
+                    {
+                      'type': 'text',
+                      'text': {
+                        'value': '<p class="block">butt</p>'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            'transition': 'none',
+            'background': {
+              'type': 'webmap',
+              'webmap': {
+                'type': 'webmap',
+                'id': '7db923b748c44666b09afc83ce833b87',
+                'options': {
+                  'interaction': 'enabled'
+                },
+                'extras': {
+                  'locate': {
+                    'enabled': false
+                  },
+                  'search': {
+                    'enabled': false
+                  },
+                  'legend': {
+                    'enabled': false
+                  }
+                },
+                'layers': [],
+                'extent': {
+                  'xmin': -14265018.319190815,
+                  'ymin': 2321631.7425200106,
+                  'xmax': -7724454.682886593,
+                  'ymax': 7110870.186754741,
+                  'spatialReference': {
+                    'wkid': 102100
+                  }
+                }
+              }
+            },
+            'foreground': {
+              'panels': [
+                {
+                  'layout': 'scroll-full',
+                  'settings': {
+                    'position-x': 'left',
+                    'size': 'medium',
+                    'style': 'background',
+                    'theme': 'white-over-black'
+                  },
+                  'blocks': [
+                    {
+                      'type': 'text',
+                      'text': {
+                        'value': '<p class="block">en</p>'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            'transition': 'fade-fast',
+            'background': {
+              'type': 'empty',
+              'empty': 'empty'
+            },
+            'foreground': {
+              'panels': [
+                {
+                  'layout': 'scroll-full',
+                  'settings': {
+                    'position-x': 'left',
+                    'size': 'medium',
+                    'style': 'background',
+                    'theme': 'white-over-black'
+                  },
+                  'blocks': [
+                    {
+                      'type': 'text',
+                      'text': {
+                        'value': '<p class="block"></p>'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+};

--- a/test/fixtures/mapjournal-storymap.ts
+++ b/test/fixtures/mapjournal-storymap.ts
@@ -1,0 +1,35 @@
+export default {
+  item: {},
+  data: {
+    values: {
+      story: {
+        sections: [
+          {
+            media: {
+              type: 'webmap',
+              webmap: {
+                id: '234'
+              }
+            }
+          },
+          {
+            media: {
+              type: 'webmap',
+              webmap: {
+                id: '567'
+              }
+            }
+          },
+          {
+            media: {
+              type: 'webpage',
+              webpage: {
+                url: 'https://www.arcgis.com/home/webscene/viewer.html?webscene=91b46c2b162c48dba264b2190e1dbcff&ui=min',
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/mapjournal-storymap.ts
+++ b/test/fixtures/mapjournal-storymap.ts
@@ -13,6 +13,14 @@ export default {
             }
           },
           {
+            notmedia: {
+              type: 'other',
+              props: {
+                val: '234'
+              }
+            }
+          },
+          {
             media: {
               type: 'webmap',
               webmap: {
@@ -22,9 +30,25 @@ export default {
           },
           {
             media: {
+              type: 'webmap',
+              webmap: {
+                noid: 'othervalue'
+              }
+            }
+          },
+          {
+            media: {
               type: 'webpage',
               webpage: {
                 url: 'https://www.arcgis.com/home/webscene/viewer.html?webscene=91b46c2b162c48dba264b2190e1dbcff&ui=min',
+              }
+            }
+          },
+          {
+            media: {
+              type: 'webpage',
+              webpage: {
+                nourl: 'notaurl',
               }
             }
           }

--- a/test/fixtures/mapseries-storymap.ts
+++ b/test/fixtures/mapseries-storymap.ts
@@ -1,0 +1,28 @@
+export default {
+  item: {},
+  data: {
+    values: {
+      webmap: '234',
+      story: {
+        entries: [
+          {
+            media: {
+              type: 'webmap',
+              webmap: {
+                id: '234'
+              }
+            }
+          },
+          {
+            media: {
+              type: 'webmap',
+              webmap: {
+                id: '567'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/mapseries-storymap.ts
+++ b/test/fixtures/mapseries-storymap.ts
@@ -2,7 +2,7 @@ export default {
   item: {},
   data: {
     values: {
-      webmap: '234',
+      webmap: '123',
       story: {
         entries: [
           {

--- a/test/fixtures/test-layout.ts
+++ b/test/fixtures/test-layout.ts
@@ -1,0 +1,746 @@
+
+// Layout json
+export default {
+  'sections': [
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': 'valid',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent',
+          'image': 'https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/city-skyline.jpg'
+        },
+        'color': '#ffffff'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'jumbotron-card',
+                'settings': {
+                  'header': 'Layout Templating',
+                  'subheader': 'Test Site for Converting to Templates',
+                  'minHeight': '150',
+                  'showLocation': false,
+                  'imageUrl': '',
+                  'fileSrc': '',
+                  'cropSrc': '',
+                  'isUrl': true,
+                  'isFile': false,
+                  'state': '',
+                  'position': {
+                    'x': 'center',
+                    'y': 'center'
+                  },
+                  'display': {},
+                  'showSearch': false
+                }
+              },
+              'width': 12
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': '#292b47',
+          'image': ''
+        },
+        'color': '#ffffff'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': "<p class=\"lead text-justify\">This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let's achieve our goals together</p>"
+                }
+              },
+              'width': 12,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': true,
+          'isUrl': false,
+          'state': 'valid',
+          'display': {
+            'crop': {
+              'transformAxis': 'x',
+              'position': {
+                'x': 0,
+                'y': 0
+              },
+              'scale': {
+                'current': 0,
+                'original': 0
+              },
+              'container': {
+                'left': 20,
+                'top': 138,
+                'width': 860,
+                'height': 463.419689119171
+              },
+              'natural': {
+                'width': 772,
+                'height': 416
+              },
+              'output': {
+                'width': 820,
+                'height': 250.41968911917098
+              },
+              'version': 2,
+              'rendered': {
+                'width': 860,
+                'height': 463.419689119171
+              }
+            }
+          },
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent',
+          'fileSrc': 'udemy-avatar.jpg',
+          'cropSrc': 'hub-image-card-crop-i82b07y2e.png',
+          'cropId': 'i82b07y2e'
+        },
+        'color': '#ff0000'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'follow-initiative-card',
+                'settings': {
+                  'initiativeId': 'c5963a6bb6244eb8b8fb4f56cb0bef4c',
+                  'callToActionText': 'By following this initiative you will get updates about new events, surveys, and tools that you can use to help us achieve our goals.',
+                  'callToActionAlign': 'center',
+                  'buttonText': 'Follow',
+                  'buttonAlign': 'center',
+                  'buttonStyle': 'outline',
+                  'unfollowButtonText': 'Unfollow'
+                }
+              },
+              'width': 12
+            }
+          ]
+        },
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'items/gallery-card',
+                'settings': {
+                  'query': {
+                    'mode': 'dynamic',
+                    'num': 4,
+                    'types': [
+                      'dataset'
+                    ],
+                    'tags': [],
+                    'groups': [
+                      {
+                        'title': 'Maryland Socrata LALALAL',
+                        'id': '9db8bf78132c44ae83131fd879c87881'
+                      }
+                    ],
+                    'ids': []
+                  },
+                  'display': {
+                    'imageType': 'Icons',
+                    'viewText': 'Explore',
+                    'dropShadow': 'medium',
+                    'cornerStyle': 'round'
+                  },
+                  'version': 2,
+                  'orgId': '97KLIFOSt5CxbiRI',
+                  'siteId': ''
+                }
+              },
+              'width': 12
+            }
+          ]
+        },
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'event-list-card',
+                'settings': {
+                  'calendarEnabled': true,
+                  'defaultView': 'calendar',
+                  'eventListTitleAlign': 'left',
+                  'height': 500,
+                  'listEnabled': true,
+                  'showTitle': true,
+                  'title': 'List of Upcoming Events',
+                  'initiativeIds': [
+                    'c5963a6bb6244eb8b8fb4f56cb0bef4c'
+                  ]
+                }
+              },
+              'width': 12
+            }
+          ]
+        },
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'jumbotron-card',
+                'settings': {
+                  'header': 'Find Data',
+                  'subheader': '',
+                  'minHeight': '50',
+                  'showLocation': false,
+                  'imageUrl': '',
+                  'fileSrc': '',
+                  'cropSrc': '',
+                  'isUrl': true,
+                  'isFile': false,
+                  'state': '',
+                  'position': {
+                    'x': 'center',
+                    'y': 'center'
+                  },
+                  'display': {},
+                  'showSearch': true,
+                  'searchPlaceholder': 'Search for Data'
+                }
+              },
+              'width': 12
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': '#ffffff'
+        },
+        'color': '#808080'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<h2 class="text-center">Explore your data</h2>'
+                }
+              },
+              'width': 12,
+              'showEditor': false
+            }
+          ]
+        },
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Agriculture',
+                  'type': 'keyword',
+                  'keyword': 'agriculture',
+                  'iconName': 'environment',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#008000'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Boundaries',
+                  'type': 'keyword',
+                  'keyword': 'boundaries',
+                  'iconName': 'boundaries',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#ffa500'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Business',
+                  'type': 'keyword',
+                  'keyword': 'business',
+                  'iconName': 'structure',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#136fbf'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Community Safety',
+                  'type': 'keyword',
+                  'keyword': 'safety',
+                  'iconName': 'mapproducts',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#ffd700'
+                }
+              },
+              'width': 3
+            }
+          ]
+        },
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': ' Education',
+                  'type': 'keyword',
+                  'keyword': 'education',
+                  'iconName': 'historic',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#4b0082'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Health',
+                  'type': 'keyword',
+                  'keyword': 'health',
+                  'iconName': 'health',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#008080'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Housing',
+                  'type': 'keyword',
+                  'keyword': 'housing',
+                  'iconName': 'locationaddress',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#808080'
+                }
+              },
+              'width': 3
+            },
+            {
+              'component': {
+                'name': 'category-card',
+                'settings': {
+                  'category': 'Transportation',
+                  'type': 'keyword',
+                  'keyword': 'transportation',
+                  'iconName': 'transportation',
+                  'iconType': 'library',
+                  'customAltText': '',
+                  'iconColor': '#000000'
+                }
+              },
+              'width': 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent'
+        },
+        'color': '#4c4c4c'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<h2 class="text-center"> Applications</h2>\n\n<div class="col-xs-12"><p class="text-left">Apps provide simple access to information and tools for you to collect data and help your users understand your data. We recommend exploring the apps below for helping engage around specific goals and initiatives. Try updating the below cards or use the Gallery Card in the site editor</p><br /></div>\n\n<div class="col-xs-12 col-sm-6 col-md-3">\n<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/app-proximity.jpg" alt="Local Perspective Map View">\n    </div>\n    <div class="card-content">\n      <h4><a href="http://www.arcgis.com/home/item.html?id=6e02b538bea841ed858ef9f52709b655">Local Perspective</a></h4>\n      <p style="min-height: 50px">Configure apps to provide focused citizen experiences.</p>\n      <div aria-label="actions" class="btn-group btn-group-justified" role="group">\n        <a class="btn btn-default" href="#">Details</a><a class="btn btn-primary" href="#">View</a>\n      </div>\n    </div>\n  </div>\n</div>\n</div>\n\n<div class="col-xs-12 col-sm-6 col-md-3">\n<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/story-map-editor.jpg" alt="Story Maps Cascade">\n    </div>\n    <div class="card-content">\n      <h4><a href="https://storymaps.arcgis.com">Story Maps</a></h4>\n      <p style="min-height: 50px">Tell stories about local issues and solutions.</p>\n      <div aria-label="actions" class="btn-group btn-group-justified" role="group">\n        <a class="btn btn-default" href="#">Details</a><a class="btn btn-primary" href="#">View</a>\n      </div>\n    </div>\n  </div>\n</div>\n</div>\n\n<div class="clearfix visible-sm-block"></div>\n\n<div class="col-xs-12 col-sm-6 col-md-3">\n<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/mobile-app.jpg" alt="Survey123 Mobile View">\n    </div>\n    <div class="card-content">\n      <h4><a href="https://survey123.arcgis.com/">Survey 123</a></h4>\n      <p  style="min-height: 50px">Hear from your community.</p>\n      <div aria-label="actions" class="btn-group btn-group-justified" role="group">\n        <a class="btn btn-default" href="#">Details</a><a class="btn btn-primary" href="#">View</a>\n      </div>\n    </div>\n  </div>\n</div>\n</div>\n\n\n<div class="col-xs-12 col-sm-6 col-md-3">\n<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/ops-dashboard.jpg" alt="Ops Dashboard">\n    </div>\n    <div class="card-content">\n      <h4><a href="http://hub.arcgis.com/pages/open-data">Ops Dashboard</a></h4>\n      <p  style="min-height: 50px">Monitor your data</p>\n      <div aria-label="actions" class="btn-group btn-group-justified" role="group">\n        <a class="btn btn-default" href="#">Details</a><a class="btn btn-primary" href="#">View</a>\n      </div>\n    </div>\n  </div>\n</div>\n</div>\n<div class="col-xs-12">\n<p class="text-right"><a href="http://solutions.arcgis.com" class="btn btn-primary">Explore More Apps</a></p>\n</div>'
+                }
+              },
+              'width': 12,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': 'valid',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent',
+          'image': 'https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/blue-map-banner.jpg'
+        },
+        'color': '#ffffff'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': "<h2 class=\"text-center\">Unlock the Data</h2>\n<p class=\"text-center\">Anyone can use this data at no cost. Download raw data and share your insights with your teams or build new applications that serve specific users.</p>\n\n<div class=\"row\">\n<div class=\"col-xs-12 col-sm-6 col-md-3\">\n<div class=\"p p-default\">\n<div class=\"p-heading\"><center><img src=\"https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/explore.png\" /></center></div>\n<div class=\"p-body\">\n<h3 class=\"text-center\">Explore</h3>\n<p class=\"text-center\">Dig into the data.</p>\n</div></div>\n</div>\n<div class=\"col-xs-12 col-sm-6 col-md-3\">\n<div class=\"p p-default\">\n<div class=\"p-heading\"><center><img src=\"https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/visualize.png\" /></center></div>\n<div class=\"p-body\">\n<h3 class=\"text-center\">Visualize & Analyze</h3>\n<p class=\"text-center\">Highlight spatial patterns and discover trends.</p>\n</div></div>\n</div>\n<div class=\"col-xs-12 col-sm-6 col-md-3\">\n<div class=\"p p-default\">\n<div class=\"p-heading\"><center><img src=\"https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/build.png\" /></center></div>\n<div class=\"p-body\">\n<h3 class=\"text-center\">Build</h3>\n<p class=\"text-center\">Develop new apps using templates and API's.</p>\n</div></div>\n</div>\n<div class=\"col-xs-12 col-sm-6 col-md-3\">\n<div class=\"p p-default\">\n<div class=\"p-heading\"><center><img src=\"https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/share.png\" /></center></div>\n<div class=\"p-body\">\n<h3 class=\"text-center\">Share</h3>\n<p class=\"text-center\">Embed analysis on your website.</p>\n</div></div>\n</div>\n</div>"
+                }
+              },
+              'width': 12,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent'
+        },
+        'color': '#4c4c4c'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '## Data Narratives \n \n<p class="lead">Datasets have a story to tell. Engage and inspire your audience by combining text, images, and other multimedia content with maps. You have the local knowledge and expertise, now begin and sustain a meaningful connection with your users.</p>\n\n<p class="text-center">[Learn More](http://storymaps.arcgis.com/en/)</p>'
+                }
+              },
+              'width': 9,
+              'showEditor': false
+            },
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/story-map-editor.jpg" alt="Story Maps Cascade">\n    </div>\n    <div class="card-content">\n      <h4><a href="https://storymaps.arcgis.com">Story Maps</a></h4>\n      <p>Share local knowledge and insights.</p>\n   <a class="btn btn-primary" href="#">View</a>\n    </div>\n  </div>\n</div>'
+                }
+              },
+              'width': 3,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': '#e9f5f8',
+          'image': ''
+        },
+        'color': '#4c4c4c'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<div class="calcite-web">\n  <div class="card-base">\n    <div class="card-image-wrap">\n      <img class="card-image" src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/people.jpg" alt="Developers">\n    </div>\n    <div class="card-content">\n      <h4><a href="https://developers.arcgis.com">ArcGIS Online for Developers</a></h4>\n      <p>Develop new apps and solutions for your community.</p>\n   <a class="btn btn-primary" href="#">View</a>\n    </div>\n  </div>\n</div>'
+                }
+              },
+              'width': 3,
+              'showEditor': false
+            },
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': "## Connect to your data's API\n \n<p class=\"lead\">Use this platform to spur innovation from other teams and stay on top of the latest technology. Utilizing open standards, interoperability, data, APIs, and code can connect you directly your data's community.</a>\n\n<p class=\"text-center\"><a href=\"http://www.esri.com/software/open\">Vision</a> | <a href=\"http://developers.arcgis.com\">Developer API</a></p>"
+                }
+              },
+              'width': 9,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent'
+        },
+        'color': '#4C4C4C'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': "## Cross-Functional Events\n\nData is best used in coordination between multiple departments and groups. By hosting in-person events you can share knowledge and build a cohesive collaboration to solve your more important initiatives. It is often helpful to have regular and on-going events that align with existing local community events when possible. \n\nExamples:\n- [GeoDev Meetup](http://www.esri.com/events/geodev-meetups) on visualization\n- Transportation Data Meetup, hosted by DOT\n- Public Safety and You, hosted by PD\n- Community App Challenge, hosted by Mayor's office\n- [ConnectEd](http://www.esri.com/connected) event with local Schools"
+                }
+              },
+              'width': 6,
+              'showEditor': false
+            },
+            {
+              'component': {
+                'name': 'image-card',
+                'settings': {
+                  'src': 'https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/meeting.jpg',
+                  'fileSrc': '',
+                  'cropSrc': '',
+                  'alt': 'Community Hackathon - Flickr: ajturner',
+                  'caption': 'Data working session',
+                  'captionAlign': 'center',
+                  'hyperlink': '',
+                  'hyperlinkTabOption': 'new',
+                  'isUrl': true,
+                  'isFile': false,
+                  'state': 'valid',
+                  'display': {
+                    'position': {
+                      'x': 'center',
+                      'y': 'center'
+                    },
+                    'reflow': false
+                  }
+                }
+              },
+              'width': 6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': '#dedede',
+          'image': ''
+        },
+        'color': '#757575'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<h2 class="text-center">Contact Information</h2>\n<h2 class="text-center"><span class="glyphicon glyphicon-envelope" style="margin-right:10px;"></span><a href="mailto:support@esri.com"> support@esri.com</a></h2>'
+                }
+              },
+              'width': 12,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': false,
+          'isUrl': true,
+          'state': '',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': '#f3f3ee',
+          'image': ''
+        },
+        'color': '#333333'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '<br/>\n<em>Copyright 2018. Washington, DC R&D Center (QA).</em>\n'
+                }
+              },
+              'width': 4,
+              'showEditor': false
+            },
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '## About\n\n- Link\n- Link\n- Link'
+                }
+              },
+              'width': 4,
+              'showEditor': false
+            },
+            {
+              'component': {
+                'name': 'markdown-card',
+                'settings': {
+                  'markdown': '## Contact Us \n \n- Link\n- Link\n- Link\n'
+                }
+              },
+              'width': 4,
+              'showEditor': false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  'header': {
+    'component': {
+      'name': 'site-header',
+      'settings': {
+        'fullWidth': false,
+        'iframeHeight': '150px',
+        'iframeUrl': '',
+        'links': [],
+        'logoUrl': '',
+        'title': 'Washington, DC R&D Center (QA)',
+        'markdown': '<nav class="navbar navbar-default navbar-static-top first-tier">\n  <div class="container">\n    <div class="navbar-header">\n      <div class="navbar-brand">\n        <div class="site-logo">\n          <img src="https://s3.amazonaws.com/geohub-assets/templates/sites/defaultSite/resources/50x50.png" alt="logo">\n          <h1>My Organization</h1>\n        </div>\n     </div>\n    </div>\n    <ul class="nav nav-pills pull-right" role="navigation">\n        <li><a href="#">Terms of Use</a></li>\n        <li><a href="#">Twitter</a></li>\n        <li><a href="#">Blog</a></li>\n    </ul>\n  </div>\n</nav>\n<nav class="navbar navbar-inverse navbar-static-top second-tier" role="navigation">\n      <div class="container">\n         <div class="navbar">\n          <ul class="nav navbar-nav">\n            <li class="active"><a href="#">Home</a></li>\n            <li><a href="#about">About</a></li>\n            <li><a href="#contact">Contact</a></li>\n          </ul>\n        </div>\n      </div>\n    </nav>\n',
+        'headerType': 'default'
+      }
+    }
+  }
+}

--- a/test/item-types/page.test.ts
+++ b/test/item-types/page.test.ts
@@ -1,0 +1,122 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+import {
+  getDependencies
+} from '../../src/itemTypes/page';
+
+const testLayoutWithAllSupportedCards = {
+  sections: [
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'chart-card',
+                settings: {
+                  itemId: 'cc1'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'summary-statistic-card',
+                settings: {
+                  itemId: 'cc2'
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'webmap-card',
+                settings: {
+                  webmap: 'cc3'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'items/gallery-card',
+                settings: {
+                  ids: [
+                    '0ee0b0a435db49969bbd93a7064a321c',
+                    'eb173fb9d0084c4bbd19b40ee186965f',
+                    'e8201f104dca4d8d87cb4ce1c7367257',
+                    '5a14dbb7b2f3417fb4a6ea0506c2eb26'
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('Page Item Utilities', () => {
+  
+  describe('getDependencies', () => {
+    
+    it('should not fail with a null layout', (done) => {
+      getDependencies({})
+      .then((result) => {
+        expect(result).not.toBeNull('should return something');
+        expect(Array.isArray(result)).toBeTruthy('should return an array');
+        expect(result.length).toEqual(0, 'should return an empty array');
+        done();
+      })
+
+    });
+
+    it('should extract dependencies from the layout', (done) => {
+      const pageModel = {
+        item: {},
+        data: {
+          values: {
+            layout: testLayoutWithAllSupportedCards
+          }
+        }
+      }
+      getDependencies(pageModel)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(7, 'should have 7 entries');
+          expect(r).toEqual([
+            'cc1',
+            'cc2',
+            'cc3',
+            '0ee0b0a435db49969bbd93a7064a321c',
+            'eb173fb9d0084c4bbd19b40ee186965f',
+            'e8201f104dca4d8d87cb4ce1c7367257',
+            '5a14dbb7b2f3417fb4a6ea0506c2eb26'], 'should return them');
+          done();
+        })
+    });
+
+  });
+
+});

--- a/test/item-types/page.test.ts
+++ b/test/item-types/page.test.ts
@@ -81,7 +81,7 @@ describe('Page Item Utilities', () => {
   describe('getDependencies', () => {
     
     it('should not fail with a null layout', (done) => {
-      getDependencies({})
+      return getDependencies({})
       .then((result) => {
         expect(result).not.toBeNull('should return something');
         expect(Array.isArray(result)).toBeTruthy('should return an array');
@@ -100,7 +100,7 @@ describe('Page Item Utilities', () => {
           }
         }
       }
-      getDependencies(pageModel)
+      return getDependencies(pageModel)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');

--- a/test/item-types/site.test.ts
+++ b/test/item-types/site.test.ts
@@ -79,7 +79,7 @@ describe('Site Item Utilities', () => {
   describe('getDependencies', () => {
     
     it('should not fail with a null layout', (done) => {
-      getDependencies({})
+      return getDependencies({})
         .then((result) => {
           expect(result).not.toBeNull('should return something');
           expect(Array.isArray(result)).toBeTruthy('should return an array');
@@ -98,7 +98,7 @@ describe('Site Item Utilities', () => {
           }
         }
       }
-      getDependencies(siteModel)
+      return getDependencies(siteModel)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');

--- a/test/item-types/site.test.ts
+++ b/test/item-types/site.test.ts
@@ -1,0 +1,121 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+import {getDependencies} from '../../src/itemTypes/site';
+
+const testLayoutWithAllSupportedCards = {
+  sections: [
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'chart-card',
+                settings: {
+                  itemId: 'cc1'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'summary-statistic-card',
+                settings: {
+                  itemId: 'cc2'
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'webmap-card',
+                settings: {
+                  webmap: 'cc3'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'items/gallery-card',
+                settings: {
+                  ids: [
+                    '0ee0b0a435db49969bbd93a7064a321c',
+                    'eb173fb9d0084c4bbd19b40ee186965f',
+                    'e8201f104dca4d8d87cb4ce1c7367257',
+                    '5a14dbb7b2f3417fb4a6ea0506c2eb26'
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('Site Item Utilities', () => {
+  
+  describe('getDependencies', () => {
+    
+    it('should not fail with a null layout', (done) => {
+      getDependencies({})
+        .then((result) => {
+          expect(result).not.toBeNull('should return something');
+          expect(Array.isArray(result)).toBeTruthy('should return an array');
+          expect(result.length).toEqual(0, 'should return an empty array');
+          done();
+        })
+
+    });
+
+    it('should extract dependencies from the layout', (done) => {
+      const siteModel = {
+        item: {},
+        data: {
+          values: {
+            layout: testLayoutWithAllSupportedCards
+          }
+        }
+      }
+      getDependencies(siteModel)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(7, 'should have 7 entries');
+          expect(r).toEqual([
+            'cc1',
+            'cc2',
+            'cc3',
+            '0ee0b0a435db49969bbd93a7064a321c',
+            'eb173fb9d0084c4bbd19b40ee186965f',
+            'e8201f104dca4d8d87cb4ce1c7367257',
+            '5a14dbb7b2f3417fb4a6ea0506c2eb26'], 'should return them');
+          done();
+        })
+      
+    });
+
+  });
+
+});

--- a/test/item-types/storymap.test.ts
+++ b/test/item-types/storymap.test.ts
@@ -1,0 +1,124 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+import { 
+  getDependencies,
+  getCascadeDependencies,
+  getMapJournalDependencies,
+  getMapSeriesDependencies
+ } from '../../src/itemTypes/storymap';
+import TestCascade from '../fixtures/cascade-storymap';
+import TestMapJournal from '../fixtures/mapjournal-storymap';
+import TestMapSeries from '../fixtures/mapseries-storymap';
+import {cloneObject} from '../../src/utils/object-helpers';
+
+describe('Story Maps :: ', () => {
+  describe('generic functions', () => {
+    
+    describe('getting dependencies', () => {
+      it('can get dependencies for a cascade', (done) => {
+        const m = {
+          item: {
+            typeKeywords: ['Story Map', 'Cascade']
+          },
+          data: cloneObject(TestCascade)
+        };
+        getDependencies(m)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(4, 'should find 4');
+          expect(r.includes('234a94478490445cb4a57878451cb4b8')).toBeTruthy();
+          expect(r.includes('7db923b748c44666b09afc83ce833b87')).toBeTruthy();
+          done();
+        });
+      });
+
+      it('works for Map Journal', (done) => {
+        const m = cloneObject(TestMapJournal);
+        m.typeKeywords = ['Story Map', 'MapJournal']
+
+        getDependencies(m)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(3, 'should have 3 entries');
+          expect(r).toEqual(['234', '567', '91b46c2b162c48dba264b2190e1dbcff']);
+          done();
+        });
+      });
+
+      it('works for Map Series', (done) => {
+        const m = cloneObject(TestMapSeries);
+        m.typeKeywords = ['Story Map', 'mapseries']
+  
+        getDependencies(m)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(2, 'should have 2 entries');
+          expect(r).toEqual(['234', '567']);
+          done();
+        });
+      });
+    });
+
+    
+
+
+  });
+  describe('Cascade :: ', () => {
+    it('gets deps from deep in cascade', () => {
+      const m = {
+        item: {},
+        data: cloneObject(TestCascade)
+      };
+      const r = getCascadeDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(4, 'should find 4');
+      expect(r.includes('234a94478490445cb4a57878451cb4b8')).toBeTruthy();
+      expect(r.includes('7db923b748c44666b09afc83ce833b87')).toBeTruthy();
+    });
+
+  });
+
+  describe('MapJournal :: ', () => {
+    
+    it('gets dependencies for a map journal', () => {
+      const r = getMapJournalDependencies(cloneObject(TestMapJournal));
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(3, 'should have 3 entries');
+      expect(r).toEqual(['234', '567', '91b46c2b162c48dba264b2190e1dbcff']);
+
+    });
+    
+
+  });
+
+  describe('Map Series :: ', () => {
+    it('gets dependencies', () => {
+      const r = getMapSeriesDependencies(cloneObject(TestMapSeries));
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(2, 'should have 2 entries');
+      expect(r).toEqual(['234', '567']);
+    });
+
+  });
+  
+});

--- a/test/item-types/storymap.test.ts
+++ b/test/item-types/storymap.test.ts
@@ -36,7 +36,7 @@ describe('Story Maps :: ', () => {
           },
           data: cloneObject(TestCascade)
         };
-        getDependencies(m)
+        return getDependencies(m)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');
@@ -51,7 +51,7 @@ describe('Story Maps :: ', () => {
         const m = cloneObject(TestMapJournal);
         m.typeKeywords = ['Story Map', 'MapJournal']
 
-        getDependencies(m)
+        return getDependencies(m)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');
@@ -65,7 +65,7 @@ describe('Story Maps :: ', () => {
         const m = cloneObject(TestMapSeries);
         m.typeKeywords = ['Story Map', 'mapseries']
   
-        getDependencies(m)
+        return getDependencies(m)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');
@@ -83,7 +83,7 @@ describe('Story Maps :: ', () => {
           data: {}
         };
   
-        getDependencies(m)
+        return getDependencies(m)
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');

--- a/test/item-types/storymap.test.ts
+++ b/test/item-types/storymap.test.ts
@@ -69,10 +69,28 @@ describe('Story Maps :: ', () => {
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
           expect(Array.isArray(r)).toBeTruthy('should be an array');
-          expect(r.length).toEqual(2, 'should have 2 entries');
-          expect(r).toEqual(['234', '567']);
+          expect(r.length).toEqual(3, 'should have 3 entries');
+          expect(r).toEqual(['123','234', '567']);
           done();
         });
+      });
+
+      it('returns empty array if run on a non-storymap item', (done) => {
+        const m = {
+          item: {
+            typeKeywords: ['other']
+          },
+          data: {}
+        };
+  
+        getDependencies(m)
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+          expect(Array.isArray(r)).toBeTruthy('should be an array');
+          expect(r.length).toEqual(0, 'should have 0 entries');
+          done();
+        });
+        
       });
     });
 
@@ -94,6 +112,18 @@ describe('Story Maps :: ', () => {
       expect(r.includes('7db923b748c44666b09afc83ce833b87')).toBeTruthy();
     });
 
+    it('works with no sections', () => {
+      const m = {
+        item: {},
+        data: cloneObject(TestCascade)
+      };
+      delete m.data.values.sections;
+      const r = getCascadeDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(0, 'should find 0');
+    });
+
   });
 
   describe('MapJournal :: ', () => {
@@ -106,7 +136,15 @@ describe('Story Maps :: ', () => {
       expect(r).toEqual(['234', '567', '91b46c2b162c48dba264b2190e1dbcff']);
 
     });
-    
+
+    it('works if no sections present', () => {
+      const m = cloneObject(TestMapJournal);
+      delete m.data.values.story.sections;
+      const r = getMapJournalDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(0, 'should have 0 entries');
+    });
 
   });
 
@@ -115,8 +153,39 @@ describe('Story Maps :: ', () => {
       const r = getMapSeriesDependencies(cloneObject(TestMapSeries));
       expect(r).toBeTruthy('should return a value');
       expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(3, 'should have 3 entries');
+      expect(r).toEqual(['123','234', '567']);
+    });
+
+    it('removes duplicates', () => {
+      const m = cloneObject(TestMapSeries);
+      // create a dupe
+      m.data.values.webmap = '234';
+      const r = getMapSeriesDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
       expect(r.length).toEqual(2, 'should have 2 entries');
       expect(r).toEqual(['234', '567']);
+    });
+
+    it('works if no webmap is present', () => {
+      const m = cloneObject(TestMapSeries);
+      delete m.data.values.webmap;
+      const r = getMapSeriesDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(2, 'should have 2 entries');
+      expect(r).toEqual(['234', '567']);
+    });
+
+    it('works if no entries are present', () => {
+      const m = cloneObject(TestMapSeries);
+      delete m.data.values.story.entries;
+      const r = getMapSeriesDependencies(m);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(1, 'should have 1 entries');
+      expect(r).toEqual(['123']);
     });
 
   });

--- a/test/item-types/survey.test.ts
+++ b/test/item-types/survey.test.ts
@@ -23,7 +23,7 @@ describe('Surveys', () => {
   describe('get dependencies', () => {
     
     it('always returns an empty array', (done) => {
-      getDependencies({item:{}, data:{}})
+      return getDependencies({item:{}, data:{}})
         .then((r) => {
           expect(r).toBeTruthy('should return a value');
             expect(Array.isArray(r)).toBeTruthy('should be an array');

--- a/test/item-types/survey.test.ts
+++ b/test/item-types/survey.test.ts
@@ -14,14 +14,24 @@
  | limitations under the License.
  */
 
-/**
- * Return a list of items this survey depends on.
- * We just return an empty array because the deployment
- * process for a Survey will utilize the S123 API, which
- * handles creating the feature services etc etc
- */
-export function getDependencies (
-  model: any
-  ): Promise<string[]>  {
-    return Promise.resolve([]);
-};
+import {
+  getDependencies
+} from '../../src/itemTypes/survey'
+
+describe('Surveys', () => {
+  
+  describe('get dependencies', () => {
+    
+    it('always returns an empty array', (done) => {
+      getDependencies({item:{}, data:{}})
+        .then((r) => {
+          expect(r).toBeTruthy('should return a value');
+            expect(Array.isArray(r)).toBeTruthy('should be an array');
+            expect(r.length).toEqual(0, 'should have 0 entries');
+          done();
+        });
+    });
+
+  });
+
+});

--- a/test/item-types/webappbuilder.test.ts
+++ b/test/item-types/webappbuilder.test.ts
@@ -1,0 +1,62 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+ import {
+   getDependencies
+ } from '../../src/itemTypes/webappbuilder';
+
+ describe('Web App Builder', () => {
+   
+  describe('getDependencies', () => {
+    
+    it('should return the itemid if it exists', (done) => {
+      const model = {
+        item: {},
+        data: {
+          map: {
+            itemId: '3ef'
+          }
+        }
+      };
+      getDependencies(model)
+      .then((r) => {
+        expect(Array.isArray(r)).toBeTruthy();
+        expect(r.length).toEqual(1, 'should have one dep');
+        expect(r.indexOf('3ef')).toBeGreaterThan(-1, 'should have one dep');
+        done();
+      })
+      
+    });
+
+    it('should return empty array if itemId does not exist', (done) => {
+      const model = {
+        item: {},
+        data: {
+          map: {
+          }
+        }
+      };
+      getDependencies(model)
+      .then((r) => {
+        expect(Array.isArray(r)).toBeTruthy();
+        expect(r.length).toEqual(0, 'should have no deps');
+        done();
+      })
+    });
+
+  });
+
+ });

--- a/test/item-types/webappbuilder.test.ts
+++ b/test/item-types/webappbuilder.test.ts
@@ -31,7 +31,7 @@
           }
         }
       };
-      getDependencies(model)
+      return getDependencies(model)
       .then((r) => {
         expect(Array.isArray(r)).toBeTruthy();
         expect(r.length).toEqual(1, 'should have one dep');
@@ -49,7 +49,7 @@
           }
         }
       };
-      getDependencies(model)
+      return getDependencies(model)
       .then((r) => {
         expect(Array.isArray(r)).toBeTruthy();
         expect(r.length).toEqual(0, 'should have no deps');

--- a/test/item-types/webmappingapplication.test.ts
+++ b/test/item-types/webmappingapplication.test.ts
@@ -1,0 +1,103 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+
+import {
+  getDependencies,
+} from '../../src/itemTypes/webmappingapplication';
+
+
+describe('Web Mapping Application', () => {
+  
+  describe('getDependencies', () => {
+
+    it('returns various ids from named props in generic items', (done) => {
+      const m = {
+        item: {
+          typeKeywords: ['Javascript']
+        },
+        data: {
+          webmap: '3ef',
+          itemId: 'bc3',
+          values: {
+            webmap: 'ef3',
+            group: 'bc7'
+          }
+        }
+      };
+      getDependencies(m)
+      .then((r) => {
+        expect(Array.isArray(r)).toBeTruthy('should be an array');
+        expect(r.length).toEqual(4, 'should have 4 entries');
+        expect(r).toEqual(['3ef', 'bc3', 'ef3', 'bc7']);
+        done();
+      })
+    });
+
+    it('processes a storymap', (done) => {
+      const m = {
+        item: {
+          typeKeywords: ['Story Map', 'MapJournal']
+        },
+        data: {
+          values: {
+            story: {
+              sections: [
+                {
+                  media: {
+                    type: 'webmap',
+                    webmap: {
+                      id: '234'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      };
+      getDependencies(m)
+      .then((r) => {
+        expect(Array.isArray(r)).toBeTruthy('should be an array');
+        expect(r.length).toEqual(1, 'should have 1 entries');
+        expect(r).toEqual(['234']);
+        done();
+      })
+    });
+
+    it('processes a WAB', (done) => {
+      const m = {
+        item: {
+          typeKeywords: ['Web AppBuilder']
+        },
+        data: {
+          map: {
+            itemId: '3ef'
+          }
+        }
+      };
+      getDependencies(m)
+      .then((r) => {
+        expect(Array.isArray(r)).toBeTruthy('should be an array');
+        expect(r.length).toEqual(1, 'should have 1 entries');
+        expect(r).toEqual(['3ef']);
+        done();
+      })
+    });
+    
+  });
+
+});

--- a/test/item-types/webmappingapplication.test.ts
+++ b/test/item-types/webmappingapplication.test.ts
@@ -38,7 +38,7 @@ describe('Web Mapping Application', () => {
           }
         }
       };
-      getDependencies(m)
+      return getDependencies(m)
       .then((r) => {
         expect(Array.isArray(r)).toBeTruthy('should be an array');
         expect(r.length).toEqual(4, 'should have 4 entries');
@@ -69,7 +69,7 @@ describe('Web Mapping Application', () => {
           }
         }
       };
-      getDependencies(m)
+      return getDependencies(m)
       .then((r) => {
         expect(Array.isArray(r)).toBeTruthy('should be an array');
         expect(r.length).toEqual(1, 'should have 1 entries');
@@ -89,7 +89,7 @@ describe('Web Mapping Application', () => {
           }
         }
       };
-      getDependencies(m)
+      return getDependencies(m)
       .then((r) => {
         expect(Array.isArray(r)).toBeTruthy('should be an array');
         expect(r.length).toEqual(1, 'should have 1 entries');

--- a/test/utils/is-guid.test.ts
+++ b/test/utils/is-guid.test.ts
@@ -14,20 +14,15 @@
  | limitations under the License.
  */
 
-/**
- * Page Item Utility Functions
- */
-import { getProp } from '../utils/object-helpers';
-import { getLayoutDependencies } from '../utils/layout-dependencies';
+import isGuid from '../../src/utils/is-guid';
 
-/**
- * Return a list of items this page depends on.
- * Currently this is just considering the layout
- */
-export function getDependencies (
-  model: any
-  ): Promise<string[]>  {
-  const layout = getProp(model, 'data.values.layout') || {};
-  return Promise.resolve(getLayoutDependencies(layout));
-};
-
+describe('isGuid', () => {
+  it('works', () => {
+    expect(isGuid(1234)).toBeFalsy();
+    expect(isGuid({prop: 'val'})).toBeFalsy();
+    expect(isGuid('1234')).toBeFalsy();
+    expect(isGuid('imnotaguid')).toBeFalsy();
+    expect(isGuid('76c3db4812d44f0087850093837e7a90')).toBeTruthy();
+    expect(isGuid('{371acc8b-85cf-4251-8c01-7d0e48bac7e3}')).toBeTruthy();
+  });
+});

--- a/test/utils/item-helpers.test.ts
+++ b/test/utils/item-helpers.test.ts
@@ -1,0 +1,105 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+ import {
+   hasTypeKeyword,
+   hasAnyKeyword,
+   parseIdFromUrl
+ } from '../../src/utils/item-helpers';
+
+describe('item-helpers', () => {
+  
+  describe('hasKeyword', () => {
+    it('accepts a model', () => {
+      const m = {
+        item: {
+          typeKeywords: ['foo', 'bar']
+        }
+      }
+      expect(hasTypeKeyword(m,'foo')).toBeTruthy();
+      expect(hasTypeKeyword(m,'not-present')).toBeFalsy();
+    });
+    it('accepts an item', () => {
+      const i = {
+        typeKeywords: ['foo', 'bar']
+      };
+      expect(hasTypeKeyword(i,'foo')).toBeTruthy();
+      expect(hasTypeKeyword(i,'not-present')).toBeFalsy();
+    });
+    it('works if typeKeywords is undefined', () => {
+      const i = {
+        notTypeKeywords: ['foo', 'bar']
+      };
+      expect(hasTypeKeyword(i,'foo')).toBeFalsy();
+      expect(hasTypeKeyword(i,'not-present')).toBeFalsy();
+    });
+  });
+
+  describe('hasAnyKeyword', () => {
+    it('accepts a model', () => {
+      const m = {
+        item: {
+          typeKeywords: ['foo', 'bar']
+        }
+      }
+      expect(hasAnyKeyword(m,['bar'])).toBeTruthy();
+      expect(hasAnyKeyword(m,['not-present'])).toBeFalsy();
+    });
+    it('accepts an item', () => {
+      const i = {
+        typeKeywords: ['foo', 'bar']
+      };
+      expect(hasAnyKeyword(i,['foo', 'bar'])).toBeTruthy();
+      expect(hasAnyKeyword(i,['not-present'])).toBeFalsy();
+    });
+    it('works if typeKeywords is undefined', () => {
+      const i = {
+        notTypeKeywords: ['foo', 'bar']
+      };
+      expect(hasAnyKeyword(i,['foo', 'bar'])).toBeFalsy();
+      expect(hasAnyKeyword(i,['not-present'])).toBeFalsy();
+    });
+  });
+
+
+  describe('parseIdFromUrl', () => {
+    it('works for common types', () => {
+      const examples = [
+        {
+          url: 'https://www.arcgis.com/home/webscene/viewer.html?webscene=91b46c2b162c48dba264b2190e1dbcff&ui=min',
+          expected: '91b46c2b162c48dba264b2190e1dbcff'
+        },
+        {
+          url: 'https://www.arcgis.com/home/webscene/viewer.html?webmap=81b46c2b162c48dba264b2190e1dbcff&ui=min',
+          expected: '81b46c2b162c48dba264b2190e1dbcff'
+        },
+        {
+          url: 'https://www.arcgis.com/home/webscene/viewer.html?webmap=notaguid&ui=min',
+          expected: null
+        },
+        {
+          url: 'https://www.arcgis.com/home/webscene/viewer.html',
+          expected: null
+        },
+      ];
+      examples.forEach(ex => {
+        const r = parseIdFromUrl(ex.url);
+        expect(r).toEqual(ex.expected);
+      });
+    });
+  });
+
+});

--- a/test/utils/item-helpers.test.ts
+++ b/test/utils/item-helpers.test.ts
@@ -94,6 +94,10 @@ describe('item-helpers', () => {
           url: 'https://www.arcgis.com/home/webscene/viewer.html',
           expected: null
         },
+        {
+          url: null,
+          expected: null
+        }
       ];
       examples.forEach(ex => {
         const r = parseIdFromUrl(ex.url);

--- a/test/utils/layout-converter.test.ts
+++ b/test/utils/layout-converter.test.ts
@@ -1,0 +1,362 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+import TestLayout from '../fixtures/test-layout';
+import {
+  convertLayoutToTemplate,
+  convertSection,
+  convertRow,
+  convertCard,
+  convertFollowCard,
+  convertEventListCard,
+  convertItemGalleryCard,
+  convertImageCard,
+  convertJumbotronCard
+} from '../../src/utils/layout-converter'
+
+
+describe('Layout Converter', () => {
+  it('should convert the layout', () => {
+    const result = convertLayoutToTemplate(TestLayout);
+    const layout = result.layout;
+    // this is a very basic assertion, but we cover the sub-functions below
+    expect(layout.sections.length).toEqual(TestLayout.sections.length, 'should have same number of sections');
+    expect(result.assets.length).toEqual(2, 'should return 2 assets');
+  });
+
+  it('should convert a section', () => {
+    const s = {
+      'containment': 'fixed',
+      'isFooter': false,
+      'style': {
+        'background': {
+          'isFile': true,
+          'isUrl': false,
+          'state': 'valid',
+          'display': {},
+          'transparency': 0,
+          'position': {
+            'x': 'center',
+            'y': 'center'
+          },
+          'color': 'transparent',
+          'fileSrc': 'mcmaster.jpg',
+          'cropSrc': 'hub-image-card-crop-i77o2qytl.png',
+          'cropId': 'i77o2qytl'
+        },
+        'color': '#ffffff'
+      },
+      'rows': [
+        {
+          'cards': [
+            {
+              'component': {
+                'name': 'jumbotron-card',
+                'settings': {
+                  'header': 'Layout Templating',
+                  'subheader': 'Test Site for Converting to Templates',
+                  'minHeight': '150',
+                  'showLocation': false,
+                  'imageUrl': '',
+                  'fileSrc': '',
+                  'cropSrc': '',
+                  'isUrl': true,
+                  'isFile': false,
+                  'state': '',
+                  'position': {
+                    'x': 'center',
+                    'y': 'center'
+                  },
+                  'display': {},
+                  'showSearch': false
+                }
+              },
+              'width': 12
+            }
+          ]
+        }
+      ]
+    };
+    const result = convertSection(s);
+    const section = result.section;
+    const assets = result.assets;
+    expect(assets.length).toEqual(2, 'should have two assets');
+    expect(assets[0]).toEqual(s.style.background.fileSrc, 'should have fileSrc');
+    expect(assets[1]).toEqual(s.style.background.cropSrc, 'should have cropSrc');
+    expect(section.containment).toEqual('fixed', 'section object should remain');
+    expect(section.rows.length).toEqual(1, 'should have one row');
+    expect(section.rows[0].cards.length).toEqual(1, 'should have one card in first row');
+  });
+
+  it('should convert a row', () => {
+    const r = {
+      cards: [
+        {
+          'component': {
+            'name': 'follow-initiative-card',
+            'settings': {
+              'initiativeId': 'c5963a6bb6244eb8b8fb4f56cb0bef4c',
+              'callToActionText': 'By following this initiative you will get updates about new events, surveys, and tools that you can use to help us achieve our goals.',
+              'callToActionAlign': 'center',
+              'buttonText': 'Follow',
+              'buttonAlign': 'center',
+              'buttonStyle': 'outline',
+              'unfollowButtonText': 'Unfollow'
+            }
+          },
+          'width': 12
+        }
+      ]
+    };
+    const result = convertRow(r);
+    expect(result.assets.length).toEqual(0, 'should have no assets');
+    const chkCard = result.cards[0];
+    const srcCard = r.cards[0];
+    expect(chkCard).not.toEqual(srcCard, 'should return a clone');
+    expect(chkCard.component.name).toEqual(srcCard.component.name, 'name should be the same');
+  });
+
+  describe('Card Converters', () => {
+    
+    it('should return a clone if card is not processed', () => {
+      const c = {
+        component: {
+          name: 'not-a-real-component',
+          settings: {
+            boo: 'blarg'
+          }
+        }
+      };
+      const result = convertCard(c).card;
+      expect(result).not.toBe(c, 'should return a clone');
+      expect(result.component.name).toEqual(c.component.name, 'name should be the same');
+      expect(result.component.settings.boo).toEqual(c.component.settings.boo, 'setting should be the same');
+    });
+    
+    it('should convert follow-card', () => {
+      const c = {
+        'component': {
+          'name': 'follow-initiative-card',
+          'settings': {
+            'initiativeId': 'c5963a6bb6244eb8b8fb4f56cb0bef4c',
+            'callToActionText': 'By following this initiative you will get updates about new events, surveys, and tools that you can use to help us achieve our goals.',
+            'callToActionAlign': 'center',
+            'buttonText': 'Follow',
+            'buttonAlign': 'center',
+            'buttonStyle': 'outline',
+            'unfollowButtonText': 'Unfollow'
+          }
+        },
+        'width': 12
+      };
+      const result = convertFollowCard(c).card;
+      expect(result.component.settings.initiativeId).toEqual('{{initiative.id}}', 'Should inject initiative id');
+      const r2 = convertCard(c).card;
+      expect(r2.component.settings.initiativeId).toEqual('{{initiative.id}}', 'Should inject initiative id');
+    });
+
+    it('should convert event list card', () => {
+      const c = {
+        'component': {
+          'name': 'event-list-card',
+          'settings': {
+            'calendarEnabled': true,
+            'defaultView': 'calendar',
+            'eventListTitleAlign': 'left',
+            'height': 500,
+            'listEnabled': true,
+            'showTitle': true,
+            'title': 'List of Upcoming Events',
+            'initiativeIds': [
+              'c5963a6bb6244eb8b8fb4f56cb0bef4c'
+            ]
+          }
+        },
+        'width': 12
+      };
+      const result = convertEventListCard(c).card;
+      expect(result.component.settings.initiativeIds[0]).toEqual('{{initiative.id}}', 'Should inject initiative id');
+      const r2 = convertCard(c).card;
+      expect(r2.component.settings.initiativeIds[0]).toEqual('{{initiative.id}}', 'Should inject initiative id');
+    });
+
+    it('should convert gallery card', () => {
+      const c = {
+        'component': {
+          'name': 'items/gallery-card',
+          'settings': {
+            'query': {
+              'mode': 'dynamic',
+              'num': 4,
+              'types': [
+                'dataset'
+              ],
+              'tags': [] as any,
+              'groups': [
+                {
+                  'title': 'Maryland Socrata',
+                  'id': '9db8bf78132c44ae83131fd879c87881'
+                },
+                {
+                  'title': 'Another',
+                  'id': 'some-other-id'
+                }
+              ],
+              'ids': [] as any
+            },
+            'display': {
+              'imageType': 'Icons',
+              'viewText': 'Explore',
+              'dropShadow': 'medium',
+              'cornerStyle': 'round'
+            },
+            'version': 2,
+            'orgId': '97KLIFOSt5CxbiRI',
+            'siteId': ''
+          }
+        },
+        'width': 12
+      };
+      const result = convertItemGalleryCard(c).card;
+      expect(result.component.settings.query.groups.length).toEqual(1, 'only have one group');
+      expect(result.component.settings.query.groups[0].id).toEqual('{{initiative.collaborationGroupId}}', 'initaitive group');
+      expect(result.component.settings.query.groups[0].title).toEqual('{{initiative.name}}', 'initaitive group');
+      expect(result.component.settings.orgId).toEqual('{{organization.id}}', 'orgid');
+      expect(result.component.settings.siteId).toEqual('', 'should be empty');
+      const result2 = convertCard(c).card;
+      expect(result2.component.settings.query.groups.length).toEqual(1, 'only have one group');
+      expect(result2.component.settings.query.groups[0].id).toEqual('{{initiative.collaborationGroupId}}', 'initaitive group');
+      expect(result2.component.settings.query.groups[0].title).toEqual('{{initiative.name}}', 'initaitive group');
+      expect(result2.component.settings.orgId).toEqual('{{organization.id}}', 'orgid');
+      expect(result2.component.settings.siteId).toEqual('', 'should be empty');
+      c.component.settings.siteId = '3EF-SOME-ID';
+      const result3 = convertItemGalleryCard(c).card;
+      expect(result3.component.settings.siteId).toEqual('{{appid}}', 'Only set siteId if its set');
+      const result4 = convertCard(c).card;
+      expect(result4.component.settings.siteId).toEqual('{{appid}}', 'Only set siteId if its set');
+    });
+
+    it('converts an image card', () => {
+      const card = {
+        'component': {
+          'name': 'image-card',
+          'settings': {
+            'src': '',
+            'fileSrc': 'doge.jpg',
+            'cropSrc': 'hub-image-card-crop-i8orjmsva.png',
+            'alt': '',
+            'caption': '',
+            'captionAlign': 'center',
+            'hyperlink': '',
+            'hyperlinkTabOption': 'new',
+            'isUrl': false,
+            'isFile': true,
+            'state': 'valid',
+            'display': {
+              'position': {
+                'x': 'left',
+                'y': 'top'
+              },
+              'reflow': true,
+              'crop': {
+                'transformAxis': 'x',
+              }
+            },
+            'cropId': 'i8orjmsva'
+          }
+        },
+        'width': 12
+      };
+      const result = convertImageCard(card);
+      expect(result.assets.length).toEqual(2, 'should have two assets');
+      expect(result.assets[0]).toEqual(card.component.settings.fileSrc, 'should have fileSrc');
+      expect(result.assets[1]).toEqual(card.component.settings.cropSrc, 'should have cropSrc');
+      const result2 = convertCard(card);
+      expect(result2.assets.length).toEqual( 2, 'should have two assets');
+      expect(result2.assets[0]).toEqual(card.component.settings.fileSrc, 'should have fileSrc');
+      expect(result2.assets[1]).toEqual(card.component.settings.cropSrc, 'should have cropSrc');
+    });
+
+    it('converts a jumbotron card', () => {
+      const card = {
+        'component': {
+          'name': 'jumbotron-card',
+          'settings': {
+            'header': 'Layout Templating',
+            'subheader': 'Test Site for Converting to Templates',
+            'minHeight': '150',
+            'showLocation': false,
+            'imageUrl': '',
+            'fileSrc': 'turner-large.jpg',
+            'cropSrc': 'hub-image-card-crop-i45dvu2pz.png',
+            'isUrl': false,
+            'isFile': true,
+            'state': 'valid',
+            'position': {
+              'x': 'center',
+              'y': 'top'
+            },
+            'display': {
+              'crop': {
+                'transformAxis': 'x',
+                'position': {
+                  'x': 0,
+                  'y': 0
+                },
+                'scale': {
+                  'current': 0,
+                  'original': 0
+                },
+                'container': {
+                  'left': 20,
+                  'top': 15,
+                  'width': 860,
+                  'height': 527.421875
+                },
+                'natural': {
+                  'width': 2048,
+                  'height': 1256
+                },
+                'output': {
+                  'width': 820,
+                  'height': 512.421875
+                },
+                'version': 2,
+                'rendered': {
+                  'width': 860,
+                  'height': 527.421875
+                }
+              }
+            },
+            'showSearch': false,
+            'cropId': 'i45dvu2pz'
+          }
+        },
+        'width': 12
+      };
+      const result = convertJumbotronCard(card);
+      expect(result.assets.length).toEqual( 2, 'should have two assets');
+      expect(result.assets[0]).toEqual( card.component.settings.fileSrc, 'should have fileSrc');
+      expect(result.assets[1]).toEqual(card.component.settings.cropSrc, 'should have cropSrc');
+      const result2 = convertCard(card);
+      expect(result2.assets.length).toEqual( 2, 'should have two assets');
+      expect(result2.assets[0]).toEqual(card.component.settings.fileSrc, 'should have fileSrc');
+      expect(result2.assets[1]).toEqual(card.component.settings.cropSrc, 'should have cropSrc');
+    });
+
+  });
+
+});

--- a/test/utils/layout-dependencies.test.ts
+++ b/test/utils/layout-dependencies.test.ts
@@ -13,7 +13,7 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-import { cloneObject } from '../../src/common';
+import { cloneObject } from '../../src/utils/object-helpers';
 import {
   getLayoutDependencies,
   getCardDependencies
@@ -40,7 +40,14 @@ const testLayout = {
                   itemId: 'cc2'
                 }
               }
-            }
+            },
+            {
+              component: {
+                name: 'items/gallery-card',
+                settings: {}
+              }
+            },
+
           ]
         }
       ]
@@ -92,6 +99,7 @@ describe('Layout Dependencies', () => {
       'e8201f104dca4d8d87cb4ce1c7367257',
       '5a14dbb7b2f3417fb4a6ea0506c2eb26'], 'should return them');
   });
+
   describe('card-specific dependencies', () => {
     
     it('should handle chart-card', () => {

--- a/test/utils/layout-dependencies.test.ts
+++ b/test/utils/layout-dependencies.test.ts
@@ -1,0 +1,172 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+import { cloneObject } from '../../src/common';
+import {
+  getLayoutDependencies,
+  getCardDependencies
+} from '../../src/utils/layout-dependencies'
+
+const testLayout = {
+  sections: [
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'chart-card',
+                settings: {
+                  itemId: 'cc1'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'summary-statistic-card',
+                settings: {
+                  itemId: 'cc2'
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      rows: [
+        {
+          cards: [
+            {
+              component: {
+                name: 'webmap-card',
+                settings: {
+                  webmap: 'cc3'
+                }
+              }
+            },
+            {
+              component: {
+                name: 'items/gallery-card',
+                settings: {
+                  ids: [
+                    '0ee0b0a435db49969bbd93a7064a321c',
+                    'eb173fb9d0084c4bbd19b40ee186965f',
+                    'e8201f104dca4d8d87cb4ce1c7367257',
+                    '5a14dbb7b2f3417fb4a6ea0506c2eb26'
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('Layout Dependencies', () => {
+  it('extracts dependencies from a whole layout', () => {
+    const r = getLayoutDependencies(cloneObject(testLayout));
+    expect(r).toBeTruthy('should return a value');
+    expect(Array.isArray(r)).toBeTruthy('should be an array');
+    expect(r.length).toEqual(7, 'should have 7 entries');
+    expect(r).toEqual([
+      'cc1',
+      'cc2',
+      'cc3',
+      '0ee0b0a435db49969bbd93a7064a321c',
+      'eb173fb9d0084c4bbd19b40ee186965f',
+      'e8201f104dca4d8d87cb4ce1c7367257',
+      '5a14dbb7b2f3417fb4a6ea0506c2eb26'], 'should return them');
+  });
+  describe('card-specific dependencies', () => {
+    
+    it('should handle chart-card', () => {
+      const c = {
+        component: {
+          name: 'chart-card',
+          settings: {
+            itemId: 'cc1'
+          }
+        }
+      };
+      const r = getCardDependencies(c);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(1, 'should have 1 entries');
+      expect(r[0]).toEqual('cc1', 'extract the id');
+    });
+
+    it('should handle stats card', () => {
+      const c = {
+        component: {
+          name: 'summary-statistic-card',
+          settings: {
+            itemId: 'cc2'
+          }
+        }
+      };
+      const r = getCardDependencies(c);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(1, 'should have 1 entries');
+      expect(r[0]).toEqual('cc2', 'extract the id');
+    });
+
+    it('should handle gallery-card', () => {
+      const c = {
+        component: {
+          name: 'items/gallery-card',
+          settings: {
+            ids: [
+              '0ee0b0a435db49969bbd93a7064a321c',
+              'eb173fb9d0084c4bbd19b40ee186965f',
+              'e8201f104dca4d8d87cb4ce1c7367257',
+              '5a14dbb7b2f3417fb4a6ea0506c2eb26'
+            ]
+          }
+        }
+      };
+      const r = getCardDependencies(c);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(4, 'should have 4 entries');
+      expect(r).toEqual([
+        '0ee0b0a435db49969bbd93a7064a321c',
+        'eb173fb9d0084c4bbd19b40ee186965f',
+        'e8201f104dca4d8d87cb4ce1c7367257',
+        '5a14dbb7b2f3417fb4a6ea0506c2eb26'
+      ], 'extract the id');
+    });
+
+    it('should handle webmap card', () => {
+      const c = {
+        component: {
+          name: 'webmap-card',
+          settings: {
+            webmap: 'cc3'
+          }
+        }
+      };
+      const r = getCardDependencies(c);
+      expect(r).toBeTruthy('should return a value');
+      expect(Array.isArray(r)).toBeTruthy('should be an array');
+      expect(r.length).toEqual(1, 'should have 1 entries');
+      expect(r[0]).toEqual('cc3', 'extract the id');
+    });
+
+  });
+});

--- a/test/utils/object-helpers.test.ts
+++ b/test/utils/object-helpers.test.ts
@@ -1,0 +1,293 @@
+/*
+ | Copyright 2018 Esri
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |    http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+ */
+
+import {
+  getProp,
+  cloneObject,
+  getProps,
+  getDeepValues
+} from '../../src/utils/object-helpers';
+
+describe('object-helpers', () => {
+
+  describe('getDeepValues', () => {
+    
+  it('returns empty array if non object sent in', () => {
+    expect(Array.isArray(getDeepValues(null, 'foo'))).toBeTruthy();
+  });
+
+  it('only looks at own props', () => {
+    const parent = {
+      prop: 'fromParent'
+    };
+    const child = Object.create(parent);
+    child.childProp = 'red';
+    expect(getDeepValues(child, 'childProp')).toEqual(['red'], 'finds own prop');
+    expect(getDeepValues(child, 'prop')).toEqual([], 'does not find parent prop');
+  });
+
+
+  it('plucks a top level value', () => {
+    const m = {
+      webmap: '3ef'
+    };
+    expect(getDeepValues(m, 'webmap')).toEqual(['3ef'], 'finds top level prop');
+  });
+
+  it('finds a nested value', () => {
+    const m = {
+      nest: {
+        webmap: '3ef',
+        str: 'just a string'
+      }
+    };
+    expect(getDeepValues(m, 'webmap')).toEqual(['3ef'], 'finds nested prop');
+  });
+
+  it('finds multiple values', () => {
+    const n = {
+      arr: [
+        {
+          webmap: '3ef'
+        },
+        {
+          component: {
+            type: {
+              webmap: 'bcf'
+            }
+          }
+        }
+      ]
+    };
+    const chk = getDeepValues(n, 'webmap');
+    expect(chk.length).toEqual(2, 'should find two in array');
+    expect(chk[0]).toEqual('3ef', 'should find string');
+    expect(chk[1]).toEqual('bcf', 'should find nested');
+  });
+
+  it('looks into arrays', () => {
+    const o = {
+      webmap: {
+        id: 'in-the-obj'
+      },
+      other: {
+        thing: {
+          webmap: {
+            id: 'three-deep'
+          }
+        }
+      },
+      arr: [
+        {
+          nest: [
+            {
+              webmap: {
+                id: 'two-arrys'
+              }
+            }
+          ]
+        }
+      ]
+    };
+    const chk2 = getDeepValues(o, 'webmap');
+    expect(chk2.length).toEqual(3, 'should find 3');
+    expect(chk2[0] as any).toEqual({id: 'in-the-obj'}, 'should find first obj');
+    expect(chk2[1] as any).toEqual({id: 'three-deep'}, 'should find nested obj');
+    expect(chk2[2] as any).toEqual({id: 'two-arrys'}, 'should find nested obj');
+  });
+  });
+  
+  describe('cloneObject', () => {
+    it("can clone a shallow object", () => {
+      const obj = {
+        color: "red",
+        length: 12
+      } as any;
+      const c = cloneObject(obj);
+      expect(c).not.toBe(obj);
+  
+      ["color", "length"].map(prop => {
+        expect(c[prop]).toEqual(obj[prop]);
+      });
+    });
+  
+    it("can clone a deep object", () => {
+      const obj = {
+        color: "red",
+        length: 12,
+        field: {
+          name: "origin",
+          type: "string"
+        }
+      } as any;
+      const c = cloneObject(obj);
+      expect(c).not.toBe(obj);
+      expect(c.field).not.toBe(obj.field);
+  
+      ["color", "length"].map(prop => {
+        expect(c[prop]).toEqual(obj[prop]);
+      });
+      ["name", "type"].map(prop => {
+        expect(c.field[prop]).toEqual(obj.field[prop]);
+      });
+    });
+  
+    it("does not stringify null", () => {
+      const obj = {
+        color: "red",
+        length: 12,
+        field: {
+          name: "origin",
+          type: null
+        }
+      } as any;
+      const c = cloneObject(obj);
+      expect(c).not.toBe(obj);
+      expect(c.field).not.toBe(obj.field);
+      expect(c.field.type).toBe(null);
+  
+      ["color", "length"].map(prop => {
+        expect(c[prop]).toEqual(obj[prop]);
+      });
+      ["name", "type"].map(prop => {
+        expect(c.field[prop]).toEqual(obj.field[prop]);
+      });
+    });
+  
+    it("can clone a deep object with an array", () => {
+      const obj = {
+        color: "red",
+        length: 12,
+        field: {
+          name: "origin",
+          type: "string"
+        },
+        names: ["steve", "james", "bob"],
+        deep: [
+          {
+            things: ["one", "two", "red", "blue"]
+          }
+        ],
+        addresses: [
+          {
+            street: "123 main",
+            city: "anytown",
+            zip: 82729
+          },
+          {
+            street: "876 main",
+            city: "anytown",
+            zip: 123992
+          }
+        ]
+      } as any;
+  
+      const c = cloneObject(obj);
+      expect(c).not.toBe(obj);
+      expect(c.field).not.toBe(obj.field);
+      expect(c.names).not.toBe(obj.names);
+      expect(c.names.length).toEqual(obj.names.length);
+      expect(Array.isArray(c.deep)).toBeTruthy();
+      expect(c.deep[0].things.length).toBe(4);
+      ["color", "length"].map(prop => {
+        expect(c[prop]).toEqual(obj[prop]);
+      });
+      ["name", "type"].map(prop => {
+        expect(c.field[prop]).toEqual(obj.field[prop]);
+      });
+      // deep array...
+      expect(Array.isArray(c.addresses)).toBeTruthy();
+      expect(c.addresses.length).toEqual(obj.addresses.length);
+  
+      c.addresses.forEach((entry: any, idx: number) => {
+        const orig = obj.addresses[idx];
+        expect(entry).not.toBe(orig);
+        ["street", "city", "zip"].map(prop => {
+          expect(entry[prop]).toBe(orig[prop]);
+        });
+      });
+    });
+  });
+
+  describe('getProp', () => {
+    
+    it('should return a property given a path', () => {
+      expect(getProp({color:'red'}, 'color')).toEqual('red', 'should return the prop');
+    });
+
+    it('should return a deep property given a path', () => {
+      expect(getProp({color: {r: 'ff', g:'00', b:'ff'}}, 'color.r')).toEqual('ff', 'should return the prop');
+    });
+
+  });
+
+  describe('getProps', () => {
+    
+    it('should return an array of props', () => {
+      const  o = {
+        one: {
+          two: {
+            three: {
+              color: 'red'
+            },
+            threeB: {
+              color: 'orange'
+            }
+          },
+          other: 'value'
+        }
+      };
+
+      const vals = getProps(o, ['one.two.three.color', 'one.two.threeB.color']);
+      expect(vals.length).toEqual(2, 'should return two values');
+      expect(vals.indexOf('red')).toBeGreaterThan(-1, 'should have red');
+      expect(vals.indexOf('orange')).toBeGreaterThan(-1, 'should have orange');
+
+    });
+
+    it('should push an array into the return values', () => {
+      const o = {
+        one: {
+          two: [
+            'a', 'b'
+          ],
+          color: 'red'
+        }
+      };
+      const vals = getProps(o, ['one.two', 'one.color']);
+      expect(vals.length).toEqual(2, 'should return two values');
+      expect(vals.indexOf('red')).toBeGreaterThan(-1, 'should have red');
+
+    });
+
+    it('should handle missing props', () => {
+      const o = {
+        one: {
+          two: [
+            'a', 'b'
+          ],
+          color: 'red'
+        }
+      };
+      const vals = getProps(o, ['one.two', 'one.color', 'thing.three']);
+      expect(vals.length).toEqual(2, 'should return two values');
+      expect(vals.indexOf('red')).toBeGreaterThan(-1, 'should have red');
+    });
+    
+
+  });
+
+});


### PR DESCRIPTION
Kinda large PR, but it pulls over a fair bit of stuff:

### Type Specific Dependency Extraction

Handlers for the following Item Types:
- Hub Site Application
- Hub Page
- Dashboard
- Web Mapping Application, with sub-type specific logic for
  - Cascade Story Map
  - Map Journal Story Map
  - Map Series Story Map
  - Web App Builder apps

All modules are located under `src/itemTypes` and all export `getDependencies(model:any): Promise<string[]>`

### Utilities
In addition a number of utility functions were hoisted into the repo:

`utils/is-guid` - returns bool indicating if the passed string is a guid or not

`utils/item-helpers`
- `hasTypeKeyword(model:any, keyword: string):boolean` returns true if the keyword exists
- `hasAnyKeyword(model:any, keywords: string[]):boolean` returns true if any of the keyword exists
- `parseIdFromUrl(url:string):string` - given a url, extracts an item id from the query string

`utils/object-helpers`
- `getProp(obj: { [index: string]: any }, path: string): any` - moved to this module
- `getProps(obj: { [index: string]: any }, paths: string[]): any[]` - get multiple props in the same call
- `cloneObject(obj: { [index: string]: any }):any` - moved to this module

#### Other Notes:

In working on this PR, I noticed that the tests for this project are focused on the top-level entry points  `fullItem.test.ts`, `solution.test.ts`, `viewing.test.ts`, which is great, except they are difficult to reason about unless you are deep deep into how the whole thing works. Additionally, it makes refactoring more difficult as you have to modify these very comprehensive test harnesses with all the fetch mocking etc etc. However, there is a pattern to help simplify things.

In ArcGIS Rest JS and Hub.js we've typically created tests that build up from lower-level functions to higher and higher level functions, and finally to the "orchestration functions". At the higher-levels we rely on spies/fakes instead of actually re-testing the lower-level functions. This allows the tests to focus on the actual logic/behavior of the module-under-test. An example of this can be seen on the tests for [initiative activation](https://github.com/Esri/hub.js/blob/master/packages/initiatives/test/activate.test.ts) over in Hub.js.

The activation module's job is to orchestrate a series of calls into other modules. So, in the test harness we have setup a number of spies...

```
...
// constructing a spy with a fake implementation...
const shareInitiativeSpy = spyOn(
        SharingAPI,
        "shareItemWithGroup"
      ).and.callFake((opts: any): Promise<any> => {
        return Promise.resolve({ success: true });
});
...
```

And after the call to `activate`, we then verify that the spies were called the expected number of times, with the correct payloads. This allows us to modify the lower-level functions without impacting this test.

```
// verifying spies were called
expect(portalSelfSpy.calls.count()).toEqual(1,"should make one call to fetch the portal");
expect(groupNamesSpy.calls.count()).toEqual(2,"should make 2 calls to check group names");
expect(createGroupSpy.calls.count()).toEqual(2,"should make 2 calls to create groups");
```

Anyhow - something to consider as this project continues to grow.