### PR TITLE
rename repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-green.svg
 [license-url]: #license
 
-## arcgis-clone-js
+## Solution.js
 
 ### Table of Contents
 


### PR DESCRIPTION
i updated every link i could find from https://github.com/Esri/arcgis-clone-js to https://github.com/Esri/solution.js but apparently i forgot the most important one.

it'd probably be a good idea to rename the actual repo before you merge this and make sure Travis is still happy.